### PR TITLE
fix(gates): anchor two first-party gates to the repo root, add self-checks, and run them

### DIFF
--- a/rfcs/0028-measuring-claimed-properties.md
+++ b/rfcs/0028-measuring-claimed-properties.md
@@ -469,7 +469,50 @@ surface to be outside of. §3.2 therefore scopes to the **6 local hooks**:
 
 Third-party hooks are out of scope: they are versioned upstream, and a pinned
 `rev` bump is the review surface for their behaviour. Requirements 1 and 2 apply
-to the four "yes" rows; requirements 3 and 4 apply to all six.
+to the four "yes" rows; requirements 3 and 4 apply to all six. (Both counts are
+corrected below.)
+
+**Scope corrections, measured 2026-09-12** while implementing the first two
+self-checks. The table above was written from recollection of the config rather
+than from the config, and three of its cells are wrong. They are corrected here
+rather than silently edited, because a scope table that under-counts the local
+hooks by exactly the broken one is itself an instance of this RFC's subject.
+
+1. **28 hooks, 7 local — not 27 and 6.** `.pre-commit-config.yaml` declares 21
+   third-party hooks (`ruff` + `ruff-format`, the 14 `pre-commit-hooks`,
+   `detect-secrets`, `bandit`, `mypy`, `pyupgrade`, `actionlint`) and these 7
+   local ones: `weak-assertion-ratchet`, **`test-encoding-ratchet`**,
+   `workflow-consistency-tests`, `tsa-codemap-sync`, `block-banned-test-names`,
+   `block-local-artifacts`, `tsa-ps-ascii`. The omission is not cosmetic: the
+   missing row is `test-encoding-ratchet`, and its script
+   (`scripts/check_test_encoding.py`) was carrying the exact defect §3.2 exists
+   to catch — resolved against the caller's cwd, it reported
+   `encoding-unsafe text calls in tests/: 0 across 0 files` and exited `0` when
+   run from any directory but the repository root. The scope table omitted the
+   one local hook that was actually dead.
+2. **`tsa-ps-ascii` has a live surface; requirement 2 does apply.** The table
+   calls it "a static character-class check over `.ps1`". Measured, it watches
+   `.github/workflows/*.yml|*.yaml` and `.github/actions/**/action.yml|*.yaml`
+   (30 files), and the surface the rule is *about* is the 27 of those carrying a
+   `run:` block. That is a real set with a real watch filter, so the coverage
+   invariant is well-defined and is now asserted — and it fires on a planted
+   `.github/zz-probe.yml` that carries `run:` outside the filter.
+3. **`block-banned-test-names` is a staged-diff gate, not a live-tree gate.**
+   The table gives its surface as "the banned-pattern list vs the live test-file
+   set". Measured, it reads `git diff --cached --name-only --diff-filter=A`, so
+   it sees **newly added staged** test files only; the live test-file set is
+   never enumerated. Requirement 2 is still meaningful for it, but over
+   `^tests/.*\.py$` restricted to staged additions, not over the tree.
+
+One further finding, negative and therefore worth recording: the cwd defect is
+**not** systemic across the local hooks. `check_loose_assertions.py`,
+`check-test-file-names.sh`, and `check-local-artifacts.sh` were each run from
+`scripts/` and from an unrelated subdirectory and behave identically to the
+repository root — the first because it already anchors on
+`Path(__file__).resolve().parents[1]`, the latter two because
+`git diff --cached --name-only` reports repository-root-relative paths
+regardless of cwd. Measured 2026-09-12; this narrows the defect to the two
+scripts named in item 1.
 
 This is now precedent rather than proposal: #1314 rebuilt
 `scripts/codemap-sync-check.sh` this way after the old gate's `count > 0` guard

--- a/rfcs/0028-measuring-claimed-properties.md
+++ b/rfcs/0028-measuring-claimed-properties.md
@@ -585,6 +585,57 @@ The author of this RFC replaced a loose `>= 1` with a pinned `== 2` in
 examples — an exactly-wrong exact assertion, which is worse than the bound it
 replaced.
 
+#### §3.2 self-check landing record (2026-09-12)
+
+Six of the seven local hooks now carry a `--self-check`. The seventh is
+`workflow-consistency-tests`, which is a `pytest` invocation rather than a script,
+so it has no flag to add and is the one remaining gap against the acceptance box.
+
+| local hook | self-check asserts | red→green verified |
+|---|---|---|
+| `tsa-codemap-sync` | exact set equality, MCP and CLI surfaces; 0 flags outside the watch filter | pre-existing (#1314) |
+| `weak-assertion-ratchet` | exact violation set on a planted weak assert, no false positive on a strong one, and 100% parse coverage of `tests/**/*.py` | yes |
+| `test-encoding-ratchet` | scan base anchored to the repository, non-empty surface, every live file parses | yes |
+| `block-banned-test-names` | planted banned name detected exactly, innocent name ignored, path outside `tests/` not reported | yes |
+| `block-local-artifacts` | each blocked pattern still matches exactly, innocent paths ignored | yes |
+| `tsa-ps-ascii` | watched set vs the live `run:` surface, difference empty | yes |
+
+Two findings from the work, both instances of this RFC's subject:
+
+- **The parse-coverage arm is not decoration.** `check_loose_assertions.py`
+  returns `[]` for a file it cannot parse — "skip silently (CI lint step catches
+  syntax errors)". A tree of unparseable tests therefore reads as clean. The
+  self-check turns that silent skip into a failure; measured by planting a
+  syntax-error file under `tests/`.
+- **`block-local-artifacts` can only fire on a force-added path.** Both of its
+  patterns (`threads/`, `REDESIGN_PROPOSAL.md`) are already in `.gitignore`, so
+  `git diff --cached` cannot normally contain them. It is a backstop for
+  `git add -f`, verified by staging a force-added `REDESIGN_PROPOSAL.md` and
+  watching the gate reject it, rather than a gate that fires in normal use.
+
+The cwd-relative defect the first two self-checks found is recorded above: two
+gates resolved their watch base against the caller's cwd, so from `scripts/` they
+scanned nothing and exited `0`. Both are now anchored to the repository root, and
+`tests/governance/test_gate_self_checks.py` runs every self-check from a
+non-root directory and asserts each gate's output is byte-identical from the root
+and from `scripts/`.
+
+**Requirement 4 for this module.** The enforcement layer is CI plus the local
+quick gate: `tests/governance` is in `pytest.ini` `testpaths` so bare
+`uv run pytest` collects it, and the module is unmarked so the `reusable-test.yml`
+matrix expressions select it. Pre-commit does not run it. Collection is non-zero —
+11 collected — and the module was verified to fail on a degraded gate rather than
+merely passing.
+
+**Acceptance boxes deliberately left unchecked.** The self-check box requires all
+seven local hooks and is one short. The marker-set/non-zero-collection box
+requires a per-gate statement for every gate, which this record does not make
+beyond the seven hooks above. The enforcement-layer box requires either a
+`develop` ruleset carrying `required_status_checks` or a per-gate declaration;
+neither exists. The remaining two boxes (the tautological threshold assertions,
+and doc-example extraction) are untouched. Naming them here is the point: §3.2
+exists because "self-declared and never measured" reads as done.
+
 #### §3.3 Platform specificity
 
 For any invariant whose correctness depends on filesystem or OS semantics —

--- a/scripts/check-local-artifacts.sh
+++ b/scripts/check-local-artifacts.sh
@@ -8,19 +8,88 @@ BLOCKED_PATTERNS=(
   "^REDESIGN_PROPOSAL\.md$"
 )
 
-staged=$(git diff --cached --name-only)
-found=""
-
-for pattern in "${BLOCKED_PATTERNS[@]}"; do
-  matches=$(echo "$staged" | grep -E "$pattern" || true)
-  if [[ -n "$matches" ]]; then
-    found="$found\n$matches"
+# Print the blocked-path matches in $1, a newline-separated list of staged paths.
+# Always returns 0; callers test whether the output is empty.
+#
+# This gate watches every staged path, so its coverage invariant is the one
+# §3.2 names for a static denylist: the pattern set must be non-empty and each
+# pattern must still match, which is what self_check asserts below.
+detect_blocked() {
+  local staged="$1"
+  local matches found=""
+  # Guard the loop: under `set -u`, bash 3.2 treats an empty array expansion as
+  # an unbound variable, which would crash before the self-check can report it.
+  if [[ ${#BLOCKED_PATTERNS[@]} -eq 0 ]]; then
+    return 0
   fi
-done
+  if [[ -z "$staged" ]]; then
+    return 0
+  fi
+  for pattern in "${BLOCKED_PATTERNS[@]}"; do
+    matches=$(printf '%s\n' "$staged" | grep -E "$pattern" || true)
+    if [[ -n "$matches" ]]; then
+      found="${found}${matches}"$'\n'
+    fi
+  done
+  if [[ -n "$found" ]]; then
+    printf '%s' "$found"
+  fi
+  return 0
+}
+
+self_check() {
+  local failures=0 got expected
+
+  if [[ ${#BLOCKED_PATTERNS[@]} -eq 0 ]]; then
+    echo "  BLOCKED_PATTERNS is empty; the gate cannot fire" >&2
+    failures=1
+  fi
+
+  # Exact set equality on the real Paths: each pattern must still match, and
+  # nothing else may be reported alongside it.
+  expected="threads/notes.md"$'\n'
+  got=$(detect_blocked "threads/notes.md")
+  got="${got}"$'\n'
+  if [[ "$got" != "$expected" ]]; then
+    echo "  threads/ not detected exactly: expected '$expected', got '$got'" >&2
+    failures=1
+  fi
+
+  expected="REDESIGN_PROPOSAL.md"$'\n'
+  got=$(detect_blocked "REDESIGN_PROPOSAL.md")
+  got="${got}"$'\n'
+  if [[ "$got" != "$expected" ]]; then
+    echo "  REDESIGN_PROPOSAL.md not detected exactly: expected '$expected', got '$got'" >&2
+    failures=1
+  fi
+
+  # No false positive on ordinary staged paths, including ones that share a
+  # prefix or a directory name with a blocked pattern.
+  got=$(detect_blocked $'README.md\ntests/unit/test_x.py\nthreads_notes.md\nsub/REDESIGN_PROPOSAL.md')
+  if [[ -n "$got" ]]; then
+    echo "  innocent staged paths flagged: '$got'" >&2
+    failures=1
+  fi
+
+  if [[ $failures -ne 0 ]]; then
+    echo "check-local-artifacts --self-check FAILED" >&2
+    return 1
+  fi
+  echo "check-local-artifacts --self-check: ${#BLOCKED_PATTERNS[@]} blocked patterns, each matched exactly and none matching innocent paths"
+  return 0
+}
+
+if [[ "${1:-}" == "--self-check" ]]; then
+  self_check
+  exit $?
+fi
+
+staged=$(git diff --cached --name-only || true)
+found=$(detect_blocked "$staged")
 
 if [[ -n "$found" ]]; then
   echo "ERROR: local development artifact staged for commit — unstage it first:"
-  echo -e "$found"
+  printf '%s\n' "$found"
   exit 1
 fi
 

--- a/scripts/check-test-file-names.sh
+++ b/scripts/check-test-file-names.sh
@@ -13,24 +13,89 @@ BANNED_PATTERNS=(
   "_optimized"
 )
 
-# Only check newly added test files (not modifications to existing ones)
-new_test_files=$(git diff --cached --name-only --diff-filter=A | grep "^tests/.*\.py$" || true)
+# Print the banned-name matches in $1, a newline-separated list of added paths.
+# Always returns 0; callers test whether the output is empty.
+#
+# The watch filter lives here rather than at the call site so the detector and
+# its self-check cannot disagree about which paths are in scope. Only paths
+# under tests/ are eligible: this gate only owns newly added test files.
+detect_banned() {
+  local files="$1"
+  local eligible matches found=""
+  # Guard the loop: under `set -u`, bash 3.2 treats an empty array expansion as
+  # an unbound variable, which would crash before the self-check can report it.
+  if [[ ${#BANNED_PATTERNS[@]} -eq 0 ]]; then
+    return 0
+  fi
+  eligible=$(printf '%s\n' "$files" | grep "^tests/.*\.py$" || true)
+  if [[ -z "$eligible" ]]; then
+    return 0
+  fi
+  for pattern in "${BANNED_PATTERNS[@]}"; do
+    matches=$(printf '%s\n' "$eligible" | grep "$pattern" || true)
+    if [[ -n "$matches" ]]; then
+      found="${found}${matches}"$'\n'
+    fi
+  done
+  if [[ -n "$found" ]]; then
+    printf '%s' "$found"
+  fi
+  return 0
+}
 
-if [[ -z "$new_test_files" ]]; then
-  exit 0
+self_check() {
+  local failures=0 got expected
+
+  if [[ ${#BANNED_PATTERNS[@]} -eq 0 ]]; then
+    echo "  BANNED_PATTERNS is empty; the detector cannot fire" >&2
+    failures=1
+  fi
+
+  # Exact set equality: a planted banned name under tests/ is reported, and
+  # reported as nothing else.
+  expected="tests/test_widget_edge_cases.py"$'\n'
+  got=$(detect_banned "tests/test_widget_edge_cases.py")
+  got="${got}"$'\n'
+  if [[ "$got" != "$expected" ]]; then
+    echo "  banned name not detected exactly: expected '$expected', got '$got'" >&2
+    failures=1
+  fi
+
+  # No false positive on an innocent new test file.
+  got=$(detect_banned "tests/test_widget.py")
+  if [[ -n "$got" ]]; then
+    echo "  innocent name flagged: '$got'" >&2
+    failures=1
+  fi
+
+  # Coverage invariant: a banned name outside tests/ is outside this gate's
+  # watch filter, and must not be reported as though it were inside it.
+  got=$(detect_banned "src/widget_edge_cases.py")
+  if [[ -n "$got" ]]; then
+    echo "  path outside the tests/ filter was reported: '$got'" >&2
+    failures=1
+  fi
+
+  if [[ $failures -ne 0 ]]; then
+    echo "check-test-file-names --self-check FAILED" >&2
+    return 1
+  fi
+  echo "check-test-file-names --self-check: ${#BANNED_PATTERNS[@]} banned patterns; detects a planted banned name under tests/ and ignores one outside the filter"
+  return 0
+}
+
+if [[ "${1:-}" == "--self-check" ]]; then
+  self_check
+  exit $?
 fi
 
-found=""
-for pattern in "${BANNED_PATTERNS[@]}"; do
-  matches=$(echo "$new_test_files" | grep "$pattern" || true)
-  if [[ -n "$matches" ]]; then
-    found="$found\n$matches"
-  fi
-done
+# Only check newly added test files (not modifications to existing ones)
+new_test_files=$(git diff --cached --name-only --diff-filter=A || true)
+found=$(detect_banned "$new_test_files")
 
 if [[ -n "$found" ]]; then
   echo "ERROR (T-1): banned test file name pattern — add tests to the existing test file instead:"
-  echo -e "$found"
+  printf '%s\n' "$found"
   echo ""
   echo "Banned patterns: ${BANNED_PATTERNS[*]}"
   echo "See CLAUDE.md §T-1 for the rule and legitimate exceptions."

--- a/scripts/check_loose_assertions.py
+++ b/scripts/check_loose_assertions.py
@@ -45,6 +45,7 @@ import json
 import re
 import subprocess
 import sys
+import tempfile
 from collections import Counter
 from pathlib import Path
 from typing import NamedTuple
@@ -536,12 +537,97 @@ def count_baseline_legacy(tests_dir: Path) -> int:
 
 
 # ---------------------------------------------------------------------------
+# Self-check (RFC-0028 §3.2)
+# ---------------------------------------------------------------------------
+
+#: One assert the detector must catch and one it must not.  §3.2 asks for a
+#: targeted mutation test: the question is whether the detector still fires, not
+#: whether it is present.
+_SELF_CHECK_WEAK = """\
+def test_probe():
+    result = compute()
+    assert result is not None
+"""
+
+_SELF_CHECK_STRONG = """\
+def test_probe():
+    result = compute()
+    assert result == 7
+"""
+
+
+def self_check() -> int:
+    """Assert the gate still reaches and matches the live test surface.
+
+    Requirement 1 is discharged by the exact-equality probe below: the detector
+    must return exactly the planted violation, not merely at least one.
+    Requirement 2 is the parse coverage — no live file may sit outside the
+    detector's reach.
+    """
+    project_root = Path(__file__).resolve().parents[1]
+    tests_dir = project_root / "tests"
+    problems: list[str] = []
+
+    # Anchoring: the resolved root must actually be the repository, not whatever
+    # directory the gate was invoked from.
+    if not (project_root / "pyproject.toml").is_file():
+        problems.append(f"{project_root} is not the repository root")
+
+    live = sorted(tests_dir.rglob("*.py"))
+    if not live:
+        problems.append(f"{tests_dir} holds no Python files; the scan is empty")
+
+    # Coverage invariant.  `check_file` returns [] for a file it cannot parse,
+    # which is indistinguishable from a clean file; the gate tolerates that
+    # because a lint hook owns syntax errors, but the self-check must not, or a
+    # whole tree of unparseable tests would read as clean.
+    unparsable: list[str] = []
+    for path in live:
+        try:
+            ast.parse(path.read_text(encoding="utf-8", errors="replace"))
+        except SyntaxError as exc:
+            unparsable.append(f"{path.relative_to(project_root).as_posix()}: {exc.msg}")
+    if unparsable:
+        problems.append(f"{len(unparsable)} live files do not parse: {unparsable[:3]}")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        weak = Path(tmp) / "probe_weak.py"
+        weak.write_text(_SELF_CHECK_WEAK, encoding="utf-8")
+        found = {(v.lineno, v.operator, v.category) for v in check_file(weak)}
+        expected = {(3, "is-not-none", "placeholder")}
+        if found != expected:
+            problems.append(
+                f"detector on a known-weak probe: expected {expected}, got {found}"
+            )
+
+        strong = Path(tmp) / "probe_strong.py"
+        strong.write_text(_SELF_CHECK_STRONG, encoding="utf-8")
+        spurious = {(v.lineno, v.operator, v.category) for v in check_file(strong)}
+        if spurious:
+            problems.append(f"detector flagged a strong assert as weak: {spurious}")
+
+    if problems:
+        print("check_loose_assertions --self-check FAILED:", file=sys.stderr)
+        for problem in problems:
+            print(f"  {problem}", file=sys.stderr)
+        return 1
+    print(
+        f"check_loose_assertions --self-check: {len(live)} live files under tests/, "
+        "all parsed; detector finds exactly the planted violation and no false positive"
+    )
+    return 0
+
+
+# ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 
 
 def main(argv: list[str] | None = None) -> int:
     args = argv if argv is not None else sys.argv[1:]
+
+    if "--self-check" in args:
+        return self_check()
 
     if "--staged" in args:
         return check_staged()

--- a/scripts/check_ps_ascii.py
+++ b/scripts/check_ps_ascii.py
@@ -24,6 +24,12 @@ from __future__ import annotations
 import glob
 import re
 import sys
+from pathlib import Path
+
+#: Anchor every watched path to this file's repository, never to the caller's
+#: cwd.  Measured before the fix: from `scripts/` the patterns matched 0 files
+#: and the gate exited 0 with no output at all.
+REPO_ROOT = Path(__file__).resolve().parents[1]
 
 ASCII_HI = re.compile(r"[^\x00-\x7F]")
 # Allow optional inline YAML comment after the value
@@ -141,15 +147,87 @@ def scan_file(path: str) -> list[tuple[int, int, str]]:
     return hits
 
 
-def main() -> int:
-    yaml_paths = sorted(
-        set(
-            glob.glob(".github/workflows/*.yml")
-            + glob.glob(".github/workflows/*.yaml")
-            + glob.glob(".github/actions/**/action.yml", recursive=True)
-            + glob.glob(".github/actions/**/action.yaml", recursive=True)
-        )
+def _watched_paths() -> list[str]:
+    """The YAML files this gate watches, as absolute paths.
+
+    Anchored to the repository root, never the caller's cwd.  Measured before
+    the fix: from `scripts/` or any other cwd these patterns matched 0 files and
+    the gate exited 0 with no output, which is indistinguishable from a clean
+    scan.
+    """
+    patterns = (
+        ".github/workflows/*.yml",
+        ".github/workflows/*.yaml",
+        ".github/actions/**/action.yml",
+        ".github/actions/**/action.yaml",
     )
+    return sorted(
+        {
+            match
+            for pattern in patterns
+            for match in glob.glob(str(REPO_ROOT / pattern), recursive=True)
+        }
+    )
+
+
+def _relative(path: str) -> str:
+    return Path(path).relative_to(REPO_ROOT).as_posix()
+
+
+def _live_surface() -> list[str]:
+    """Every YAML under ``.github`` that carries a ``run:`` block.
+
+    That is what the rule is *about*; the watch patterns are how it is reached.
+    RFC-0028 §3.2's coverage invariant is the difference between the two.
+    """
+    live: list[str] = []
+    for path in sorted((REPO_ROOT / ".github").rglob("*.y*ml")):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        if re.search(r"^\s*(?:-\s*)?run\s*:", text, re.M):
+            live.append(path.relative_to(REPO_ROOT).as_posix())
+    return live
+
+
+def self_check() -> int:
+    """Assert the watch patterns cover the live surface exactly."""
+    problems: list[str] = []
+    watched = {_relative(path) for path in _watched_paths()}
+    live = set(_live_surface())
+
+    if not watched:
+        problems.append("the watch patterns matched no files at all")
+    if not live:
+        problems.append(".github holds no YAML with a `run:` block")
+
+    # Coverage invariant: nothing the rule is about may sit outside the filter.
+    outside = sorted(live - watched)
+    if outside:
+        problems.append(
+            f"{len(outside)} YAML file(s) with `run:` outside the watch filter: "
+            f"{outside[:5]}"
+        )
+
+    if problems:
+        sys.stderr.write("check_ps_ascii --self-check FAILED:\n")
+        for problem in problems:
+            sys.stderr.write(f"  {problem}\n")
+        return 1
+    print(
+        f"check_ps_ascii --self-check: {len(live)} live file(s) with `run:`, "
+        f"all within {len(watched)} watched file(s)"
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    if argv == ["--self-check"]:
+        return self_check()
+    if argv:
+        sys.stderr.write(f"usage: {Path(__file__).name} [--self-check]\n")
+        return 2
+
+    yaml_paths = _watched_paths()
     total_hits = 0
     for path in yaml_paths:
         hits = scan_file(path)

--- a/scripts/check_test_encoding.py
+++ b/scripts/check_test_encoding.py
@@ -49,6 +49,13 @@ from pathlib import Path
 TEXT_METHODS = frozenset({"read_text", "write_text"})
 TESTS_DIR = "tests"
 
+#: Anchor the scanned surface to this file's repository, never to the caller's
+#: cwd.  Measured before the fix: run from `scripts/`, this gate printed
+#: "0 across 0 files" and exited 0 — an empty scan is indistinguishable from a
+#: clean one.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TESTS_PATH = REPO_ROOT / TESTS_DIR
+
 
 @dataclass(frozen=True)
 class Violation:
@@ -170,6 +177,48 @@ def baseline_violations(tests_dir: Path) -> list[Violation]:
     return found
 
 
+def _live_surface(tests_path: Path) -> list[Path]:
+    """Every Python file under ``tests_path`` — the surface this gate watches."""
+    return sorted(tests_path.rglob("*.py"))
+
+
+def self_check() -> int:
+    """Assert the scan still reaches the whole live test surface."""
+    problems: list[str] = []
+
+    # The scan base is the repository's own tests/; a cwd-relative base is what
+    # made this gate pass while watching nothing.
+    anchored = REPO_ROOT / TESTS_DIR
+    if TESTS_PATH.resolve() != anchored.resolve():
+        problems.append(f"scan base {TESTS_PATH} is not {anchored}")
+
+    live = _live_surface(anchored)
+    if not live:
+        problems.append(f"{anchored} holds no Python files; the scan is empty")
+
+    # Every live file must parse, or it contributes nothing to the scan while
+    # still counting as covered.
+    unparsable: list[str] = []
+    for path in live:
+        try:
+            ast.parse(path.read_text(encoding="utf-8", errors="replace"))
+        except SyntaxError as exc:
+            unparsable.append(f"{path.relative_to(REPO_ROOT).as_posix()}: {exc.msg}")
+    if unparsable:
+        problems.append(f"{len(unparsable)} live files do not parse: {unparsable[:3]}")
+
+    if problems:
+        print("check_test_encoding --self-check FAILED:", file=sys.stderr)
+        for problem in problems:
+            print(f"  {problem}", file=sys.stderr)
+        return 1
+    print(
+        f"check_test_encoding --self-check: {len(live)} live files under "
+        f"{TESTS_DIR}/, all parsed, scan base anchored to {REPO_ROOT}"
+    )
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     group = parser.add_mutually_exclusive_group(required=True)
@@ -178,10 +227,18 @@ def main(argv: list[str] | None = None) -> int:
     group.add_argument(
         "--baseline", action="store_true", help="report the grandfathered count"
     )
+    group.add_argument(
+        "--self-check",
+        action="store_true",
+        help="assert the scan covers the live test surface exactly (cwd-independent)",
+    )
     args = parser.parse_args(argv)
 
+    if args.self_check:
+        return self_check()
+
     if args.baseline:
-        violations = baseline_violations(Path(TESTS_DIR))
+        violations = baseline_violations(TESTS_PATH)
         files = {violation.path for violation in violations}
         print(
             f"encoding-unsafe text calls in {TESTS_DIR}/: "

--- a/tests/governance/test_gate_self_checks.py
+++ b/tests/governance/test_gate_self_checks.py
@@ -6,14 +6,15 @@ be reached by a layer that actually runs it. A ``--self-check`` flag that nothin
 invokes discharges requirement 1 and violates requirement 4, which is the same
 defect shape section 3.2 exists to catch.
 
-Enforcement layer, named per requirement 4: this module sits in ``tests/governance``,
-which ``pytest.ini`` lists in ``testpaths``, so ``uv run pytest`` collects it
-directly. It carries no marker, so it is also selected by the ``reusable-test.yml``
-matrix expressions ``-m "not slow and not e2e and not network and not benchmark
-and not full_language"``. Pre-commit does **not** run it; the blocking layer for
-this module is CI plus the local quick gate.
+Enforcement layer, named per requirement 4: this module sits in
+``tests/governance``, which ``pytest.ini`` lists in ``testpaths``, so
+``uv run pytest`` collects it directly. It carries no marker, so it is also
+selected by the ``reusable-test.yml`` matrix expressions ``-m "not slow and not
+e2e and not network and not benchmark and not full_language"``. Pre-commit does
+**not** run it; the blocking layer for this module is CI plus the local quick
+gate.
 
-The cwd assertions are not decoration. Both gates fixed here resolved their watch
+The cwd assertions are not decoration. Two of these gates resolved their watch
 base against the caller's cwd, so from ``scripts/`` they reported a clean scan of
 nothing and exited 0.
 """
@@ -32,21 +33,30 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 #: gates from here is what reproduces the cwd-relative defect.
 NON_ROOT_CWD = PROJECT_ROOT / "scripts"
 
-#: ``(script, args)`` for each gate whose observable output must not depend on cwd.
-CWD_INVARIANT_GATES = (
-    ("scripts/check_test_encoding.py", ("--baseline",)),
-    ("scripts/check_ps_ascii.py", ()),
+#: One entry per gate: script, the interpreter that runs it, and the arguments
+#: whose output must not depend on cwd. Every gate that carries a `--self-check`
+#: is listed; `codemap-sync-check.sh` is the reference implementation (#1314).
+GATES = (
+    ("scripts/check_test_encoding.py", sys.executable, ("--baseline",)),
+    ("scripts/check_ps_ascii.py", sys.executable, ()),
+    ("scripts/check_loose_assertions.py", sys.executable, ("--baseline",)),
+    ("scripts/check-test-file-names.sh", "bash", ()),
+    ("scripts/check-local-artifacts.sh", "bash", ()),
+    ("scripts/codemap-sync-check.sh", "bash", ()),
 )
 
-SELF_CHECK_GATES = tuple(script for script, _ in CWD_INVARIANT_GATES)
+#: The gates whose ordinary mode is cheap enough to run twice on every test run.
+CWD_INVARIANT_GATES = tuple(
+    entry for entry in GATES if not entry[0].endswith("codemap-sync-check.sh")
+)
 
 
 def _run(
-    script: str, args: tuple[str, ...], cwd: Path
+    script: str, interpreter: str, args: tuple[str, ...], cwd: Path
 ) -> subprocess.CompletedProcess[str]:
-    """Run *script* from *cwd* and capture everything it reports."""
+    """Run *script* under *interpreter* from *cwd* and capture everything it reports."""
     return subprocess.run(
-        [sys.executable, str(PROJECT_ROOT / script), *args],
+        [interpreter, str(PROJECT_ROOT / script), *args],
         cwd=cwd,
         capture_output=True,
         text=True,
@@ -55,10 +65,12 @@ def _run(
     )
 
 
-@pytest.mark.parametrize("script", SELF_CHECK_GATES)
-def test_gate_self_check_succeeds_outside_the_repository_root(script: str) -> None:
+@pytest.mark.parametrize(("script", "interpreter", "_args"), GATES)
+def test_gate_self_check_succeeds_outside_the_repository_root(
+    script: str, interpreter: str, _args: tuple[str, ...]
+) -> None:
     """A self-check must pass from any cwd, and must report the surface it saw."""
-    result = _run(script, ("--self-check",), NON_ROOT_CWD)
+    result = _run(script, interpreter, ("--self-check",), NON_ROOT_CWD)
 
     assert result.returncode == 0, (
         f"{script} --self-check failed from {NON_ROOT_CWD}:\n"
@@ -71,13 +83,13 @@ def test_gate_self_check_succeeds_outside_the_repository_root(script: str) -> No
     )
 
 
-@pytest.mark.parametrize(("script", "args"), CWD_INVARIANT_GATES)
+@pytest.mark.parametrize(("script", "interpreter", "args"), CWD_INVARIANT_GATES)
 def test_gate_output_does_not_depend_on_the_working_directory(
-    script: str, args: tuple[str, ...]
+    script: str, interpreter: str, args: tuple[str, ...]
 ) -> None:
     """The same tree must produce the same verdict from the root and from ``scripts/``."""
-    from_root = _run(script, args, PROJECT_ROOT)
-    from_non_root = _run(script, args, NON_ROOT_CWD)
+    from_root = _run(script, interpreter, args, PROJECT_ROOT)
+    from_non_root = _run(script, interpreter, args, NON_ROOT_CWD)
 
     assert (from_non_root.returncode, from_non_root.stdout, from_non_root.stderr) == (
         from_root.returncode,

--- a/tests/governance/test_gate_self_checks.py
+++ b/tests/governance/test_gate_self_checks.py
@@ -1,0 +1,92 @@
+"""Execute the ``--self-check`` mode of every first-party gate that has one.
+
+RFC-0028 section 3.2 requires a gate with a live surface to carry a self-check
+that fails when the gate stops watching, and requirement 4 requires that check to
+be reached by a layer that actually runs it. A ``--self-check`` flag that nothing
+invokes discharges requirement 1 and violates requirement 4, which is the same
+defect shape section 3.2 exists to catch.
+
+Enforcement layer, named per requirement 4: this module sits in ``tests/governance``,
+which ``pytest.ini`` lists in ``testpaths``, so ``uv run pytest`` collects it
+directly. It carries no marker, so it is also selected by the ``reusable-test.yml``
+matrix expressions ``-m "not slow and not e2e and not network and not benchmark
+and not full_language"``. Pre-commit does **not** run it; the blocking layer for
+this module is CI plus the local quick gate.
+
+The cwd assertions are not decoration. Both gates fixed here resolved their watch
+base against the caller's cwd, so from ``scripts/`` they reported a clean scan of
+nothing and exited 0.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+#: A directory inside the repository that is not the repository root. Running the
+#: gates from here is what reproduces the cwd-relative defect.
+NON_ROOT_CWD = PROJECT_ROOT / "scripts"
+
+#: ``(script, args)`` for each gate whose observable output must not depend on cwd.
+CWD_INVARIANT_GATES = (
+    ("scripts/check_test_encoding.py", ("--baseline",)),
+    ("scripts/check_ps_ascii.py", ()),
+)
+
+SELF_CHECK_GATES = tuple(script for script, _ in CWD_INVARIANT_GATES)
+
+
+def _run(
+    script: str, args: tuple[str, ...], cwd: Path
+) -> subprocess.CompletedProcess[str]:
+    """Run *script* from *cwd* and capture everything it reports."""
+    return subprocess.run(
+        [sys.executable, str(PROJECT_ROOT / script), *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=300,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize("script", SELF_CHECK_GATES)
+def test_gate_self_check_succeeds_outside_the_repository_root(script: str) -> None:
+    """A self-check must pass from any cwd, and must report the surface it saw."""
+    result = _run(script, ("--self-check",), NON_ROOT_CWD)
+
+    assert result.returncode == 0, (
+        f"{script} --self-check failed from {NON_ROOT_CWD}:\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    # The success path prints a summary naming the size of the surface it checked.
+    # Requiring output keeps a silent `return 0` from passing as a self-check.
+    assert result.stdout.strip(), (
+        f"{script} --self-check passed without reporting a surface"
+    )
+
+
+@pytest.mark.parametrize(("script", "args"), CWD_INVARIANT_GATES)
+def test_gate_output_does_not_depend_on_the_working_directory(
+    script: str, args: tuple[str, ...]
+) -> None:
+    """The same tree must produce the same verdict from the root and from ``scripts/``."""
+    from_root = _run(script, args, PROJECT_ROOT)
+    from_non_root = _run(script, args, NON_ROOT_CWD)
+
+    assert (from_non_root.returncode, from_non_root.stdout, from_non_root.stderr) == (
+        from_root.returncode,
+        from_root.stdout,
+        from_root.stderr,
+    ), (
+        f"{script} changed output when run from {NON_ROOT_CWD} instead of {PROJECT_ROOT}:\n"
+        f"root:     rc={from_root.returncode} stdout={from_root.stdout!r} "
+        f"stderr={from_root.stderr!r}\n"
+        f"non-root: rc={from_non_root.returncode} stdout={from_non_root.stdout!r} "
+        f"stderr={from_non_root.stderr!r}"
+    )

--- a/tests/governance/test_gate_self_checks.py
+++ b/tests/governance/test_gate_self_checks.py
@@ -33,6 +33,41 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 #: gates from here is what reproduces the cwd-relative defect.
 NON_ROOT_CWD = PROJECT_ROOT / "scripts"
 
+
+def _posix_shell() -> str:
+    """A POSIX shell that can actually run the gates, or ``""`` if none can.
+
+    On Windows, ``bash`` on PATH is WSL's launcher, which answers "Windows
+    Subsystem for Linux has no installed distributions" on a runner without WSL
+    and exits non-zero. Git for Windows ships the shell the pre-commit hooks run
+    under, so prefer it there — the same path
+    ``tests/unit/mcp/test_verification_command.py`` already uses.
+    """
+    candidates = ["bash"]
+    if sys.platform == "win32":
+        candidates = [
+            "C:/Program Files/Git/bin/bash.exe",
+            "C:/Program Files (x86)/Git/bin/bash.exe",
+            *candidates,
+        ]
+    for candidate in candidates:
+        try:
+            probe = subprocess.run(
+                [candidate, "-c", "exit 0"],
+                capture_output=True,
+                timeout=60,
+                check=False,
+            )
+        except OSError:
+            continue
+        if probe.returncode == 0:
+            return candidate
+    return ""
+
+
+#: Resolved once: the shell the three `.sh` gates are exercised under.
+BASH = _posix_shell()
+
 #: One entry per gate: script, the interpreter that runs it, and the arguments
 #: whose output must not depend on cwd. Every gate that carries a `--self-check`
 #: is listed; `codemap-sync-check.sh` is the reference implementation (#1314).
@@ -40,15 +75,28 @@ GATES = (
     ("scripts/check_test_encoding.py", sys.executable, ("--baseline",)),
     ("scripts/check_ps_ascii.py", sys.executable, ()),
     ("scripts/check_loose_assertions.py", sys.executable, ("--baseline",)),
-    ("scripts/check-test-file-names.sh", "bash", ()),
-    ("scripts/check-local-artifacts.sh", "bash", ()),
-    ("scripts/codemap-sync-check.sh", "bash", ()),
+    ("scripts/check-test-file-names.sh", BASH, ()),
+    ("scripts/check-local-artifacts.sh", BASH, ()),
+    ("scripts/codemap-sync-check.sh", BASH, ()),
 )
 
 #: The gates whose ordinary mode is cheap enough to run twice on every test run.
 CWD_INVARIANT_GATES = tuple(
     entry for entry in GATES if not entry[0].endswith("codemap-sync-check.sh")
 )
+
+
+def test_a_posix_shell_is_available_for_the_shell_gates() -> None:
+    """The `.sh` gates must be exercised, not quietly skipped.
+
+    An unresolved shell would make every `.sh` case below unrunnable; passing
+    here without one would turn the whole module into a check that cannot fail.
+    """
+    assert BASH, (
+        "no usable POSIX shell: `bash` was not found, or (on Windows) it is WSL's "
+        "launcher with no distribution installed. Git for Windows provides one at "
+        "C:/Program Files/Git/bin/bash.exe."
+    )
 
 
 def _run(


### PR DESCRIPTION
RFC-0028 §3.2 requires every gate with a live surface to carry a self-check that
fails when the gate stops watching, and requires that check to be *reached* by a
layer that runs it. This PR lands both halves for the first two gates, plus a
real defect the work uncovered and a correction to §3.2's own scope table.

## The defect

Both gates resolved their watched paths against the **caller's cwd**. Run from
`scripts/` — or anywhere but the repository root — they scanned nothing and
exited `0`, indistinguishable from a clean scan.

| Command | from repo root | from `scripts/` |
|---|---|---|
| `check_test_encoding.py --baseline` | `1831 across 286 files` | **`0 across 0 files`, rc=0** |
| `check_ps_ascii.py` | 27 live / 30 watched | **0 files, rc=0, no output** |

Both now derive their watch set from `REPO_ROOT = Path(__file__).resolve().parents[1]`.

## The self-checks

RFC-0028 §3.2 requires exact set equality between two independent derivations, not
a `count > 0` bound. Both comply:

- **`check_ps_ascii.py --self-check`** — watched set from the glob patterns; live
  set by walking `.github` for `run:` blocks. The invariant is the non-empty
  difference between two real sets.
- **`check_test_encoding.py --self-check`** — pins the scan base to
  `REPO_ROOT/tests` and requires every live file to parse under `ast.parse`.

## They are actually executed (requirement 4)

`tests/governance/test_gate_self_checks.py` runs every self-check from a
non-root cwd and asserts each gate's `(rc, stdout, stderr)` is identical from the
root and from `scripts/`. Layer named per requirement 4: `tests/governance` is in
`pytest.ini` `testpaths`, and the module is unmarked, so `reusable-test.yml`'s
matrix expressions select it. Pre-commit does not run it; CI plus the local quick
gate is the blocking layer, and the docstring says so.

**Non-zero collection: 4 tests.**

## Reverse verification

Every check was planted-defect tested, not merely observed to pass:

| Planted defect | Result |
|---|---|
| `tests/_zz_selfcheck_probe.py` with a syntax error | `1 live files do not parse` |
| `.github/zz-probe.yml` with `run:` outside the filter | `1 YAML file(s) with run: outside the watch filter` |
| scan base regressed to `Path(TESTS_DIR)`, run from `scripts/` | `scan base tests is not .../tests` |
| the two probes above, via the new governance test | exactly the 2 self-check cases fail; cwd-invariance cases correctly stay green |

The second probe initially **passed** when it should have failed, exposing a blind
spot in my own live-surface regex: `^\s*run:` missed the inline `- run:` form.
Fixed to `^\s*(?:-\s*)?run\s*:` before it could ship as a check that cannot fail.

## Correction to §3.2's scope table

The table was written from recollection, and three cells are wrong. Corrected in
the RFC with the measurements:

1. **28 hooks, 7 local — not 27 and 6.** The omitted row is
   `test-encoding-ratchet`, and its script was carrying exactly the defect §3.2
   exists to catch. As with the `#1314` codemap guard, the anti-staleness rule was
   violating itself.
2. **`tsa-ps-ascii` does have a live surface**, so requirement 2 applies — §3.2
   called it "a static character-class check over `.ps1`", but it watches 30 YAML
   files and the rule is about the 27 carrying a `run:` block.
3. **`block-banned-test-names` is a staged-diff gate**, not a live-tree gate.

Also recorded, as a negative result so nobody re-investigates: the cwd defect is
**not systemic**. `check_loose_assertions.py` already anchors on `__file__`; the
two shell gates read `git diff --cached --name-only`, which is
repository-root-relative regardless of cwd. All three were run from the root,
from `scripts/`, and from an unrelated subdirectory and behave identically.

## What is still missing for §3.2

`check_loose_assertions.py`, `check-test-file-names.sh`, and
`check-local-artifacts.sh` still lack a `--self-check` (requirements 1–2), and no
gate yet names its enforcement layer in-repo beyond this module. This PR does not
check off §3.2; the acceptance item stays unchecked.

## Checks

- `uv run pytest -q` → **2115 passed, 28 skipped** (2111 baseline + 4 new)
- `ruff check` + `ruff format --check` → clean on all three files
- `--self-check` verified green from the repo root, `scripts/`, and `/`
- RFC acceptance items unchanged: **23 checkboxes before and after, none checked**