### PR TITLE
feat(callers): declare completeness instead of implying absence

### DIFF
--- a/rfcs/0028-measuring-claimed-properties.md
+++ b/rfcs/0028-measuring-claimed-properties.md
@@ -679,10 +679,10 @@ rather than dropping it.
 
 ## Acceptance criteria
 
-- [ ] §1.1 `completeness` field emitted by the callers route on both surfaces;
+- [x] §1.1 `completeness` field emitted by the callers route on both surfaces;
       response-surface contract test updated; parity test green
-- [ ] §1.1 `_LEGAL_VERDICTS` **unchanged** — no ninth verdict added
-- [ ] §1.1 `next_step` no longer claims "Symbol not in the index" for an indexed
+- [x] §1.1 `_LEGAL_VERDICTS` **unchanged** — no ninth verdict added
+- [x] §1.1 `next_step` no longer claims "Symbol not in the index" for an indexed
       symbol with unresolved callers
 - [ ] §1 corpus + one-directional invariant green
 - [ ] §1 ratchet wired into a **named** CI job **and** its marker set recorded,

--- a/rfcs/0028-measuring-claimed-properties.md
+++ b/rfcs/0028-measuring-claimed-properties.md
@@ -281,6 +281,51 @@ containing file has at least one unresolved edge. A symbol in a fully-resolved
 file must answer `complete`, so "answer `unknown` whenever the file contains a
 dynamic construct" is not a legal way to satisfy this ratchet.
 
+#### §1.2 amendment — the scope guard counted calls that cannot be local
+
+Measured 2026-09-12 on the 2,174-file self-repo corpus (164,392 CALLS rows),
+because implementation showed the guard above was far broader than its own
+justification. The sentence "an unresolved call inside a file may target anything
+that file declares" is true of the text; it is not true of the *edges* the guard
+was counting.
+
+| | gated files | share of the 2,060 files holding CALLS edges |
+|---|---|---|
+| guard as originally written | 1,562 | 75.8% |
+| after counting `external` as terminal | 1,363 | 66.2% |
+| after excluding builtin receivers (**amended definition**) | **1,029** | **50.0%** |
+
+The largest contributors were calls that cannot name a file-local symbol at all:
+`list.append` (2,327 rows), `dict.get` (369), `conn.execute` (446), `set.add`
+(275), `logger.debug` (215), `dict.items` (152), `super().__init__` (130). Before
+the amendment, a single `logger.debug(...)` barred every symbol in its file from
+ever answering `complete` — the failure the RFC's motivation attributes to
+computed dispatch, reproduced instead by ordinary attribute access.
+
+**What the guard now counts** is unchanged in intent and narrower in fact: an
+unresolved edge gates its file unless its callee is a dotted name whose receiver
+is a builtin type (`_can_target_local_symbol`, `graph/edge_store.py`). After the
+amendment, 3,635 unresolved edges are excused on this corpus and **6,674 are
+still counted** — bare names, `self.`/`cls.`, `getattr(...)`, string-keyed
+dispatch (`handlers["read_resource"]`), and any receiver that is a local variable
+(`extractors.run`) all keep gating, because each may name something the file
+declares.
+
+**Why the remaining half is not narrowed further.** The next-largest receivers are
+`conn` (689), `self` (302), `pytest` (258), `logger` (242), `tree_sitter` (172),
+`monkeypatch` (130), `extractor` (85), `path` (71). Excusing `pytest` and
+`tree_sitter` needs the file's import table joined to a project-module test;
+`conn`, `logger`, `monkeypatch`, `extractor`, and `path` are local variables bound
+to objects, which needs dataflow rather than syntax. Neither is available to the
+edge reader today, and both can under-count, which is the one direction §1
+forbids. They are recorded here as the measured remainder rather than guessed at.
+
+**Why this is a safe narrowing and not a relaxation.** Every exclusion requires
+proving the receiver is a builtin type; nothing is excused by absence of
+information. Over-counting only holds a symbol at `incomplete`, while
+under-counting certifies absence over a real edge — so the amendment removes only
+the cases where the exclusion is provable, and the ratchet above is unchanged.
+
 ### §2 — Consultation records: making non-use visible
 
 **Claim under test:** TSA is used.

--- a/rfcs/0028-measuring-claimed-properties.md
+++ b/rfcs/0028-measuring-claimed-properties.md
@@ -684,14 +684,14 @@ rather than dropping it.
 - [x] §1.1 `_LEGAL_VERDICTS` **unchanged** — no ninth verdict added
 - [x] §1.1 `next_step` no longer claims "Symbol not in the index" for an indexed
       symbol with unresolved callers
-- [ ] §1 corpus + one-directional invariant green
-- [ ] §1 ratchet wired into a **named** CI job **and** its marker set recorded,
+- [x] §1 corpus + one-directional invariant green
+- [x] §1 ratchet wired into a **named** CI job **and** its marker set recorded,
       with a proven non-zero collected count (not merely a committed file)
-- [ ] §1.2 reconciliation with `test_unknown_rate_ratchet.py` recorded in both
+- [x] §1.2 reconciliation with `test_unknown_rate_ratchet.py` recorded in both
       test files, including which gate wins on collision
-- [ ] §1.2 scope guard green: a symbol in a fully-resolved file answers
+- [x] §1.2 scope guard green: a symbol in a fully-resolved file answers
       `complete`, never `unknown`
-- [ ] §1 documented as the executable form of the conservative-resolution claim,
+- [x] §1 documented as the executable form of the conservative-resolution claim,
       cross-referenced from `ROADMAP-no1-agent-trust.md`
 - [ ] §2 **blocked until RFC-0027 is accepted and L6.2 (`QueryCost`) lands** —
       not tickable before then

--- a/rfcs/ROADMAP-no1-agent-trust.md
+++ b/rfcs/ROADMAP-no1-agent-trust.md
@@ -390,7 +390,7 @@ commit changes.
 ### Continue
 
 - Continue local-first operation, project-root security, MCP/CLI parity, JSON for both MCP and CLI, and fail-closed benchmarks.
-- Continue conservative resolution: a visible `unknown` is safer than a confident unsupported edge.
+- Continue conservative resolution: a visible `unknown` is safer than a confident unsupported edge. [RFC-0028 §1](0028-measuring-claimed-properties.md) is its executable form — a hand-checked undecidable corpus (`tests/benchmarks/claims/test_completeness_honesty_ratchet.py`) fails any answer that is a confident empty over an edge that genuinely exists, and the `completeness` field on the callers route is what carries the distinction to the caller.
 - Continue dogfooding before edits and following the emitted verification command after edits.
 - Continue exact behavioral tests, but prefer realistic corpus failures over coverage-only growth.
 

--- a/tests/benchmarks/claims/test_completeness_honesty_ratchet.py
+++ b/tests/benchmarks/claims/test_completeness_honesty_ratchet.py
@@ -1,0 +1,176 @@
+"""Claim invariant: a resolved caller list is never a confident absence.
+
+RFC-0028 §1, as an executable invariant.  The moat is honesty, not precision:
+TSA need not *resolve* an edge, but it must never answer a bare zero over a case
+where an edge genuinely exists.
+
+Corpus: ``tests/fixtures/call_graph/undecidable_project``.  Five symbols are
+reached only through dispatch a text search cannot follow — a string-keyed
+handler registry, ``getattr(self, name)``, ``globals()[name]``, and
+``importlib`` + ``getattr``.  A search for ``handle_alpha(`` finds the
+definition and never a call, which is precisely what tempts a confident "0
+callers".  Ground truth is hand-checked in ``_CASES`` below.
+
+Reconciliation with ``test_unknown_rate_ratchet.py`` (RFC-0028 §1.2).  The two
+gates point in opposite directions and do not conflict, because they measure
+different denominators:
+
+===========================  ==============================  ==========================
+                             unknown-rate cap (existing)      honesty ratchet (this file)
+===========================  ==============================  ==========================
+denominator                  every ``kind='calls'`` row        the hand-checked corpus
+unit                         a percentage                      a count
+measures                     resolution quality                honesty where resolution
+                                                               is impossible
+direction                    down is better                    fewer silent zeros is better
+===========================  ==============================  ==========================
+
+**§1 wins on collision.**  A change that lowers the repo-wide unknown rate by
+turning an undecidable case into a confident empty fails this file, and the
+existing cap may be re-pinned upward with a reviewed decision where this one may
+not be relaxed at all.  The accepted transitions are ``unknown -> resolved`` and
+``complete -> incomplete``; the forbidden one is ``unknown -> confident empty``.
+
+Scope guard (§1.2, against §3.1): §1 applies only to symbols whose containing
+file holds at least one unresolved edge.  A symbol in a fully-resolved file must
+answer ``complete``, so "answer unknown whenever the file contains a dynamic
+construct" is not a legal way to satisfy this ratchet.  Recorded here because
+the guard is what makes the corpus below meaningful rather than a blanket
+pessimism.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = [
+    pytest.mark.benchmark,
+    pytest.mark.claims_benchmark,
+]
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+CORPUS = PROJECT_ROOT / "tests" / "fixtures" / "call_graph" / "undecidable_project"
+
+#: ``(symbol, declaring file, the dispatch that reaches it)``.  Each entry is a
+#: real runtime edge that a call-site text search cannot find.
+_CASES: tuple[tuple[str, str, str], ...] = (
+    ("handle_alpha", "plugins.py", 'HANDLERS[name]() registry dispatch'),
+    ("handle_beta", "plugins.py", 'HANDLERS[name]() registry dispatch'),
+    ("method_one", "dynamic.py", "getattr(self, name)()"),
+    ("method_two", "dynamic.py", "getattr(self, name)()"),
+    ("module_level_target", "dynamic.py", "globals()[name]() and getattr(module, attr)()"),
+)
+
+#: Recorded, not ratcheted: the number of corpus cases the corpus itself proves
+#: are undecidable.  A zero here means the fixture stopped exercising the shape
+#: and the invariant below became vacuous, so it fails loudly instead.
+_EXPECTED_CORPUS_CASES = 5
+
+
+@pytest.fixture(scope="module")
+def corpus_project(tmp_path_factory) -> str:
+    """Index the corpus once and answer every case from that index."""
+    from tree_sitter_analyzer.ast_cache import ASTCache
+
+    root = tmp_path_factory.mktemp("undecidable")
+    for source in CORPUS.glob("*.py"):
+        (root / source.name).write_text(
+            source.read_text(encoding="utf-8"), encoding="utf-8"
+        )
+    cache = ASTCache(str(root))
+    try:
+        cache.index_project()
+    finally:
+        cache.close()
+    return str(root)
+
+
+def _call_site_text_hits(symbol: str) -> int:
+    """Hits for the naive tool: a call-site search for ``symbol(``."""
+    pattern = re.compile(rf"\b{re.escape(symbol)}\s*\(")
+    hits = 0
+    for source in CORPUS.glob("*.py"):
+        for line in source.read_text(encoding="utf-8").splitlines():
+            if line.lstrip().startswith(("def ", "class ", "async def ")):
+                continue
+            hits += len(pattern.findall(line))
+    return hits
+
+
+def test_the_corpus_still_exercises_the_undecidable_shape() -> None:
+    """Guard against the fixture quietly becoming trivially decidable."""
+    assert len(_CASES) == _EXPECTED_CORPUS_CASES
+    for symbol, _declaring, _dispatch in _CASES:
+        assert _call_site_text_hits(symbol) == 0, (
+            f"{symbol} is now called by name in the corpus, so the naive tool "
+            "would find it and the invariant below no longer tests anything"
+        )
+
+
+def test_corpus_records_unresolved_dispatch_under_the_expression(corpus_project) -> None:
+    """What TSA does today with a computed callee: it names the expression.
+
+    This is recorded rather than asserted as correct.  It is why a per-symbol
+    completeness query cannot see these cases: the unresolved row is attributed
+    to ``HANDLERS[name]``, which is no symbol's name, so a lookup for
+    ``handle_alpha`` finds nothing unresolved and reports a complete zero.
+    """
+    import sqlite3
+
+    conn = sqlite3.connect(f"{corpus_project}/.ast-cache/index.db")
+    try:
+        rows = conn.execute(
+            "SELECT callee_name FROM edges WHERE kind='calls' "
+            "AND callee_resolution NOT IN ('project','builtin','stdlib','local')"
+        ).fetchall()
+    finally:
+        conn.close()
+    names = {row[0] for row in rows}
+    # A dynamic site leaves a placeholder row, but keyed by the source text.
+    assert any("[" in name or "(" in name for name in names), (
+        "computed dispatch sites no longer leave an unresolved row at all; the "
+        "gap this file records has changed shape and needs re-measuring"
+    )
+    assert not names & {symbol for symbol, _f, _d in _CASES}, (
+        "a corpus symbol now appears as an unresolved callee name; re-measure "
+        "the finding this file records"
+    )
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "RFC-0028 §1 scope guard not yet implemented: completeness is derived "
+        "from unresolved edges *named after* the symbol, so a symbol reached "
+        "only by a computed dispatch in its own file answers complete with 0 "
+        "callers. §1.2 requires the symbol's containing file's unresolved "
+        "edges to gate the claim."
+    ),
+)
+@pytest.mark.asyncio
+async def test_undecidable_edge_is_never_reported_as_confidently_absent(
+    corpus_project,
+) -> None:
+    """The moat, as an executable invariant.
+
+    A confident empty answer where an edge genuinely exists is the single
+    failure mode that makes an agent conclude "safe to change" and be wrong.
+    This test does not require TSA to *resolve* the edge — being unable to
+    resolve it is acceptable and expected. It requires TSA to say so.
+    """
+    from tree_sitter_analyzer.mcp.tools.callers_tool import CodeGraphCallersTool
+
+    tool = CodeGraphCallersTool(corpus_project)
+    offenders = []
+    for symbol, declaring, dispatch in _CASES:
+        result = await tool.execute({"function_name": symbol, "output_format": "json"})
+        if result.get("caller_count", 0) == 0 and result.get("completeness") == "complete":
+            offenders.append((symbol, declaring, dispatch, result.get("completeness")))
+    assert offenders == [], (
+        "these corpus symbols have a real inbound edge but were answered with a "
+        f"confident zero: {json.dumps(offenders, indent=2)}"
+    )

--- a/tests/benchmarks/claims/test_completeness_honesty_ratchet.py
+++ b/tests/benchmarks/claims/test_completeness_honesty_ratchet.py
@@ -70,6 +70,16 @@ _CASES: tuple[tuple[str, str, str], ...] = (
 #: and the invariant below became vacuous, so it fails loudly instead.
 _EXPECTED_CORPUS_CASES = 5
 
+#: The honesty ratchet (RFC-0028 §1.2): corpus cases answered *without* a
+#: confident empty.  It may increase or hold, never decrease.
+#:
+#: It counts honest answers rather than ``unknown`` ones on purpose.  §1.2 says
+#: the count of ``unknown`` answers may never decrease, and in the same breath
+#: that ``unknown -> resolved`` is accepted — which a decreasing count cannot
+#: express.  The transition the ratchet exists to block is
+#: ``unknown -> confident empty``, so that is what it counts.
+_HONEST_ANSWER_FLOOR = 5
+
 
 @pytest.fixture(scope="module")
 def corpus_project(tmp_path_factory) -> str:
@@ -141,16 +151,45 @@ def test_corpus_records_unresolved_dispatch_under_the_expression(corpus_project)
     )
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "RFC-0028 §1 scope guard not yet implemented: completeness is derived "
-        "from unresolved edges *named after* the symbol, so a symbol reached "
-        "only by a computed dispatch in its own file answers complete with 0 "
-        "callers. §1.2 requires the symbol's containing file's unresolved "
-        "edges to gate the claim."
-    ),
-)
+@pytest.mark.asyncio
+async def test_a_symbol_in_a_fully_resolved_file_still_answers_complete(
+    tmp_path,
+) -> None:
+    """The scope guard cuts both ways (§1.2, against §3.1).
+
+    Answering ``unknown`` for every symbol in a project that contains any
+    dynamic construct would satisfy the invariant above while destroying what
+    the field is for.  The guard admits ``unknown`` only for a symbol whose own
+    file holds an unresolved edge, so a symbol in a fully-resolved file must
+    still answer ``complete`` even when a sibling file is full of dispatch.
+    """
+    from tree_sitter_analyzer.ast_cache import ASTCache
+    from tree_sitter_analyzer.mcp.tools.callers_tool import CodeGraphCallersTool
+
+    (tmp_path / "clean.py").write_text(
+        "def helper():\n    return 1\n\n\ndef clean_symbol():\n    return helper()\n",
+        encoding="utf-8",
+    )
+    # The unresolved edge lives here, in a file that declares clean_symbol not.
+    (tmp_path / "noisy.py").write_text(
+        "def noisy():\n    return HANDLERS[name]()\n",
+        encoding="utf-8",
+    )
+    cache = ASTCache(str(tmp_path))
+    try:
+        cache.index_project()
+    finally:
+        cache.close()
+
+    tool = CodeGraphCallersTool(str(tmp_path))
+    result = await tool.execute({"function_name": "clean_symbol", "output_format": "json"})
+
+    assert result["completeness"] == "complete", (
+        "a symbol whose own file is fully resolved must not inherit a sibling "
+        "file's unresolved edges"
+    )
+
+
 @pytest.mark.asyncio
 async def test_undecidable_edge_is_never_reported_as_confidently_absent(
     corpus_project,
@@ -173,4 +212,32 @@ async def test_undecidable_edge_is_never_reported_as_confidently_absent(
     assert offenders == [], (
         "these corpus symbols have a real inbound edge but were answered with a "
         f"confident zero: {json.dumps(offenders, indent=2)}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_honesty_ratchet_never_decreases(corpus_project) -> None:
+    """The ratchet half of §1.2.
+
+    A change that converts an undecidable case into a confident empty lowers
+    this count, and fails here even when every other test is green.  Raising the
+    floor is allowed when the resolver genuinely improves a case (the answer
+    becomes the edge itself); relaxing it is not.
+    """
+    from tree_sitter_analyzer.mcp.tools.callers_tool import CodeGraphCallersTool
+
+    tool = CodeGraphCallersTool(corpus_project)
+    honest = 0
+    confident_zeros = []
+    for symbol, _declaring, _dispatch in _CASES:
+        result = await tool.execute({"function_name": symbol, "output_format": "json"})
+        if result.get("caller_count", 0) == 0 and result.get("completeness") == "complete":
+            confident_zeros.append(symbol)
+        else:
+            honest += 1
+
+    assert honest >= _HONEST_ANSWER_FLOOR, (
+        f"honest answers fell to {honest}, below the pinned floor "
+        f"{_HONEST_ANSWER_FLOOR}; these corpus cases became confident empties: "
+        f"{confident_zeros}"
     )

--- a/tests/benchmarks/claims/test_unknown_rate_ratchet.py
+++ b/tests/benchmarks/claims/test_unknown_rate_ratchet.py
@@ -13,6 +13,20 @@ Measurement SQL (run against tree-sitter-analyzer self-repo index):
   SELECT ROUND(100.0 * SUM(callee_resolution = 'unknown') / COUNT(*), 1)
   FROM edges
   WHERE kind = 'calls';
+
+Reconciliation with `test_completeness_honesty_ratchet.py` (RFC-0028 §1.2).
+The two gates point in opposite directions and do not conflict, because their
+denominators differ: this file measures **resolution quality** over every
+`kind='calls'` row repo-wide and wants the percentage down, while that file
+measures **honesty where resolution is impossible** over a hand-checked corpus
+and wants fewer silent zeros. A genuine resolver improvement satisfies both —
+this rate falls and a corpus case moves from `unknown` to a resolved edge, which
+§1 accepts, because §1 forbids only the transition `unknown -> confident empty`,
+never `unknown -> resolved`.
+
+**§1 wins on collision.** Lowering this rate by turning an undecidable case into
+a confident empty fails that file, and this threshold may be re-pinned upward
+with a reviewed decision where §1 may not be relaxed at all.
 """
 
 from __future__ import annotations

--- a/tests/fixtures/call_graph/undecidable_project/callers.py
+++ b/tests/fixtures/call_graph/undecidable_project/callers.py
@@ -1,0 +1,27 @@
+"""Call sites for the undecidable corpus.
+
+The names reached here never appear next to a call. A text search for a call to
+any target finds its definition and nothing else, which is what makes a bare
+"0 callers" answer wrong rather than merely imprecise.
+
+As in ``plugins.py``, this docstring avoids writing a target name immediately
+followed by an opening parenthesis, so the corpus genuinely defeats a text
+search.
+"""
+
+from __future__ import annotations
+
+from dynamic import Service, call_through_globals, call_through_import
+from plugins import dispatch_by_name
+
+NAMES = ("alpha", "beta")
+METHODS = ("method_one", "method_two")
+
+
+def run_all() -> list[int]:
+    results = [dispatch_by_name(name) for name in NAMES]
+    service = Service()
+    results.extend(service.run_named(method) for method in METHODS)
+    results.append(call_through_globals("module_level_target"))
+    results.append(call_through_import("dynamic", "module_level_target"))
+    return results

--- a/tests/fixtures/call_graph/undecidable_project/dynamic.py
+++ b/tests/fixtures/call_graph/undecidable_project/dynamic.py
@@ -1,0 +1,37 @@
+"""Computed-attribute and reflection dispatch, invisible to a text search.
+
+Each target below is genuinely reachable, and no line names it at a call site.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+
+class Service:
+    """Attribute dispatch through a computed name."""
+
+    def method_one(self) -> int:
+        return 1
+
+    def method_two(self) -> int:
+        return 2
+
+    def run_named(self, name: str) -> int:
+        """Call a method chosen at runtime."""
+        return getattr(self, name)()
+
+
+def module_level_target() -> int:
+    return 3
+
+
+def call_through_globals(name: str) -> int:
+    """Reach a module-level function by name."""
+    return globals()[name]()
+
+
+def call_through_import(module_name: str, attr: str) -> int:
+    """Reach an attribute of a dynamically imported module."""
+    module = importlib.import_module(module_name)
+    return getattr(module, attr)()

--- a/tests/fixtures/call_graph/undecidable_project/plugins.py
+++ b/tests/fixtures/call_graph/undecidable_project/plugins.py
@@ -1,0 +1,43 @@
+"""Handler registry whose dispatch is invisible to a text search.
+
+``handle_alpha`` and ``handle_beta`` are real functions reached from
+``dispatch_by_name``, but no source line spells their names at a call: the
+registration is by string and the invocation is by dictionary lookup. A caller
+that searches for a call to either name finds the definition and nothing else,
+which is exactly the shape that tempts a confident "no callers".
+
+This docstring deliberately avoids writing a name immediately followed by an
+opening parenthesis: the corpus must defeat a *text* search, and an explanatory
+mention would give the naive tool a hit it should not have.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+HANDLERS: dict[str, Callable[[], int]] = {}
+
+
+def register(name: str):
+    """Register a handler under a string key."""
+
+    def decorate(fn: Callable[[], int]) -> Callable[[], int]:
+        HANDLERS[name] = fn
+        return fn
+
+    return decorate
+
+
+@register("alpha")
+def handle_alpha() -> int:
+    return 1
+
+
+@register("beta")
+def handle_beta() -> int:
+    return 2
+
+
+def dispatch_by_name(name: str) -> int:
+    """Invoke a registered handler by string key."""
+    return HANDLERS[name]()

--- a/tests/unit/mcp/tools/test_callers_completeness.py
+++ b/tests/unit/mcp/tools/test_callers_completeness.py
@@ -126,7 +126,13 @@ async def test_unknown_never_reports_absence(tool_with_edges) -> None:
     next_step = str(result["next_step"])
     assert "not in the index" not in next_step
     assert "unresolved" in next_step
-    assert "not evidence of absence" in result["agent_summary"]["summary_line"]
+    # The summary names the caller it found rather than only disclaiming
+    # absence: a module-level site is a real caller that #638 counts rather than
+    # lists, and saying "not evidence of absence" without saying why was the
+    # weaker version of this line.
+    summary_line = result["agent_summary"]["summary_line"]
+    assert "0 caller(s)" not in summary_line
+    assert "module-level call site(s)" in summary_line
 
 
 @pytest.mark.asyncio
@@ -159,6 +165,56 @@ async def test_cold_graph_reports_unknown_not_complete(tool_with_edges) -> None:
 
     assert result["completeness"] == "unknown"
     assert "not in the index" not in str(result["next_step"])
+
+
+@pytest.mark.asyncio
+async def test_resolved_module_level_caller_is_not_a_certified_zero(
+    tool_with_edges,
+) -> None:
+    """A counted-but-unlisted caller must not become a confident zero.
+
+    #638 counts module-level call sites instead of listing them, so the listed
+    count is not a census. Measured before this test existed: a symbol with two
+    resolved module-level callers answered `complete` with `caller_count: 0`,
+    `agent_summary` "has 0 caller(s)", and the next_step "Symbol not in the
+    index" — the exact false zero RFC-0028 §1 forbids, produced by the change
+    written to prevent it. Every edge was resolved, so the per-edge signal was
+    silent; only the unattributed count knew.
+    """
+    tool, conn = tool_with_edges
+    _insert_call(conn, caller="", caller_line=0, resolution=_RESOLVED)
+    conn.commit()
+
+    result = await _call(tool)
+
+    assert result["caller_count"] == 0
+    assert result["unattributed_call_sites"] == 1
+    assert result["completeness"] == "incomplete", (
+        "a symbol with a real, resolved module-level caller must never certify "
+        "an empty caller list"
+    )
+    assert "not in the index" not in str(result["next_step"])
+    assert "0 caller(s)" not in result["agent_summary"]["summary_line"]
+
+
+@pytest.mark.asyncio
+async def test_an_unresolved_module_level_site_does_not_claim_unreadable(
+    tool_with_edges,
+) -> None:
+    """A successfully-read count is not a failure to read.
+
+    The reason chain once tested `if unresolved_inbound:`, so a read `0` beside a
+    non-zero declaring-file count fell through to "its inbound edges could not be
+    read" — a false statement about a successful read.
+    """
+    tool, conn = tool_with_edges
+    _insert_call(conn, caller="", caller_line=0, resolution="unknown")
+    conn.commit()
+
+    result = await _call(tool)
+
+    next_step = str(result["next_step"])
+    assert "could not be read" not in next_step
 
 
 def test_unrecognised_resolution_marker_counts_as_unresolved(tmp_path) -> None:

--- a/tests/unit/mcp/tools/test_callers_completeness.py
+++ b/tests/unit/mcp/tools/test_callers_completeness.py
@@ -27,12 +27,17 @@ def _insert_call(
     caller_line: int,
     resolution: str,
     callee: str = _TARGET,
+    callee_full: str | None = None,
 ) -> None:
     """Insert one CALLS edge with a chosen resolution state.
 
     ``caller=""`` models a module-level call site: its source is the file node,
     which is what makes ``caller_name`` empty and the row "unattributed".
+    ``callee_full`` defaults to ``callee``; pass it to model an attribute call
+    (`list.append`) or a computed dispatch site whose full text differs from the
+    bare name the resolver recorded.
     """
+    full = callee_full if callee_full is not None else callee
     source = symbol_node("a.py", caller, caller_line) if caller else file_node("a.py")
     conn.execute(
         """INSERT INTO edges
@@ -48,7 +53,7 @@ def _insert_call(
             caller,
             callee,
             caller_line,
-            callee,
+            full,
             resolution,
             "a.py" if resolution == _RESOLVED else "",
         ),
@@ -120,7 +125,14 @@ async def test_unknown_never_reports_absence(tool_with_edges) -> None:
     # The epistemic status rides beside the existing verdict, which stays legal:
     # no ninth member is added to a closed cross-surface vocabulary.
     assert result["verdict"] in {
-        "SAFE", "CAUTION", "UNSAFE", "INFO", "REVIEW", "WARN", "ERROR", "NOT_FOUND",
+        "SAFE",
+        "CAUTION",
+        "UNSAFE",
+        "INFO",
+        "REVIEW",
+        "WARN",
+        "ERROR",
+        "NOT_FOUND",
     }
 
     next_step = str(result["next_step"])
@@ -143,7 +155,9 @@ async def test_real_zero_is_complete_and_may_say_not_in_index(tool_with_edges) -
     than from resolved edges and completeness is genuinely unknown.
     """
     tool, conn = tool_with_edges
-    _insert_call(conn, caller="alpha", caller_line=10, resolution=_RESOLVED, callee=_OTHER)
+    _insert_call(
+        conn, caller="alpha", caller_line=10, resolution=_RESOLVED, callee=_OTHER
+    )
     conn.commit()
 
     result = await _call(tool)
@@ -165,6 +179,79 @@ async def test_cold_graph_reports_unknown_not_complete(tool_with_edges) -> None:
 
     assert result["completeness"] == "unknown"
     assert "not in the index" not in str(result["next_step"])
+
+
+@pytest.mark.asyncio
+async def test_external_resolution_does_not_poison_the_declaring_file(
+    tool_with_edges,
+) -> None:
+    """``external`` is a terminal resolution, not an unresolved edge.
+
+    Measured on the 2,174-file self-repo corpus: ``external`` is 2.58% of all
+    CALLS edges (4,247 rows).  Counting it as unresolved barred 199 additional
+    files from ever answering ``complete`` — 1,562 files gated rather than
+    1,363.  ``synapse.py`` states the intent directly: ``external`` and
+    ``stdlib`` are terminal, "target lives outside the project, no
+    resolved_file by design", which is why the backfill refuses to re-select
+    them.  A marker the writer treats as finished must not read as unfinished.
+    """
+    tool, conn = tool_with_edges
+    _insert_call(
+        conn, caller="alpha", caller_line=10, resolution="external", callee=_OTHER
+    )
+    conn.commit()
+
+    result = await _call(tool)
+
+    assert result["unresolved_in_declaring_files"] == 0
+    assert result["completeness"] == "complete"
+
+
+@pytest.mark.asyncio
+async def test_external_edge_named_like_a_local_symbol_is_resolved(
+    tool_with_edges,
+) -> None:
+    """An ``external`` edge stays resolved when its name matches a local symbol.
+
+    §1 forbids presenting an *unresolved* edge as absence.  An ``external`` edge
+    is not unresolved: the resolver decided the callee lives outside the project.
+    ``_matches_callee`` compares bare names, so an external callee sharing a name
+    with a local symbol still reaches this count; excluding it is correct,
+    because the edge's target is the external symbol, not the local one.
+    """
+    tool, conn = tool_with_edges
+    _insert_call(conn, caller="alpha", caller_line=10, resolution="external")
+    conn.commit()
+
+    result = await _call(tool)
+
+    assert result["unresolved_inbound"] == 0
+    assert result["completeness"] == "complete"
+
+
+@pytest.mark.asyncio
+async def test_unresolved_inbound_and_caller_count_are_different_units(
+    tool_with_edges,
+) -> None:
+    """The two numbers answer different questions and are not meant to reconcile.
+
+    ``caller_count`` lists distinct call sites and excludes module-level rows;
+    ``unresolved_inbound`` counts every inbound edge.  A module-level unresolved
+    site is therefore counted (1) and unlisted (0) at the same time, which is the
+    intended reading rather than a contradiction.  Repeated edges cannot inflate
+    the count: ``edges`` is UNIQUE over
+    ``(source_node_id, target_node_id, kind, line)``.
+    """
+    tool, conn = tool_with_edges
+    _insert_call(conn, caller="", caller_line=0, resolution="unknown")
+    conn.commit()
+
+    result = await _call(tool)
+
+    assert result["caller_count"] == 0
+    assert result["unresolved_inbound"] == 1
+    assert result["unattributed_call_sites"] == 1
+    assert result["completeness"] == "unknown"
 
 
 @pytest.mark.asyncio
@@ -236,3 +323,105 @@ def test_unrecognised_resolution_marker_counts_as_unresolved(tmp_path) -> None:
         assert cache.count_unresolved_callers(_TARGET) == 1
     finally:
         cache.close()
+
+
+# ---------------------------------------------------------------------------
+# §1.2 scope guard: what may gate a file
+# ---------------------------------------------------------------------------
+#
+# The guard asks whether an unresolved call inside a declaring file could target
+# a symbol that file declares.  Before narrowing it counted every unresolved
+# edge, which gated 1,562 of the 2,060 files holding CALLS edges (75.8%) and
+# barred every symbol they declare from answering `complete`.  The largest
+# contributors cannot name a local symbol at all — `list.append` (2,327 rows),
+# `dict.get`, `set.add`, `conn.execute`, `logger.debug`.
+
+
+@pytest.mark.asyncio
+async def test_builtin_receiver_call_does_not_gate_the_file(tool_with_edges) -> None:
+    """`list.append` cannot target a symbol the file declares, so it must not gate it."""
+    tool, conn = tool_with_edges
+    _insert_call(
+        conn,
+        caller="alpha",
+        caller_line=10,
+        resolution="unknown",
+        callee="append",
+        callee_full="list.append",
+    )
+    conn.commit()
+
+    result = await _call(tool)
+
+    assert result["unresolved_in_declaring_files"] == 0
+    assert result["completeness"] == "complete"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("callee", "callee_full", "why"),
+    [
+        (
+            'handlers["read_resource"]',
+            'handlers["read_resource"]',
+            "string-keyed dispatch",
+        ),
+        ("getattr(self, name)", "getattr(self, name)", "reflection"),
+        ("self.handle", "self.handle", "own-class attribute"),
+        ("cls.build", "cls.build", "classmethod attribute"),
+        ("extractors.run", "extractors.run", "receiver is a local variable"),
+        ("local_helper", "local_helper", "bare name in scope"),
+        ("original", "original", "bare name bound at runtime"),
+    ],
+)
+async def test_potentially_local_callee_still_gates_the_file(
+    tool_with_edges, callee: str, callee_full: str, why: str
+) -> None:
+    """Everything that could name a local symbol keeps gating the file.
+
+    These are the cases §1.2 exists for.  Narrowing may only remove callees it
+    can *prove* cannot target the file; a receiver that is a local variable
+    (`extractors.run`) may well be a project object, so it stays counted.
+    """
+    tool, conn = tool_with_edges
+    _insert_call(
+        conn,
+        caller="alpha",
+        caller_line=10,
+        resolution="unknown",
+        callee=callee,
+        callee_full=callee_full,
+    )
+    conn.commit()
+
+    result = await _call(tool)
+
+    assert result["unresolved_in_declaring_files"] == 1, why
+    assert result["completeness"] != "complete", why
+
+
+@pytest.mark.asyncio
+async def test_dotted_callee_is_judged_by_receiver_not_by_substring(
+    tool_with_edges,
+) -> None:
+    """A dotted callee is excused by its receiver *text*, never by a substring.
+
+    `getattr(importlib.import_module(mod), cls).from_private_bytes` contains dots,
+    but its text before the first dot is `getattr(importlib` — not a builtin type
+    name.  A naive reading could excuse a real dispatch site; it must keep gating.
+    """
+    tool, conn = tool_with_edges
+    _insert_call(
+        conn,
+        caller="alpha",
+        caller_line=10,
+        resolution="unknown",
+        callee="from_private_bytes",
+        callee_full="getattr(importlib.import_module(mod), cls).from_private_bytes",
+    )
+    conn.commit()
+
+    result = await _call(tool)
+
+    assert result["unresolved_in_declaring_files"] == 1
+    assert result["completeness"] != "complete"

--- a/tests/unit/mcp/tools/test_callers_completeness.py
+++ b/tests/unit/mcp/tools/test_callers_completeness.py
@@ -1,0 +1,182 @@
+"""RFC-0028 §1.1 — the callers response declares its own completeness.
+
+The invariant is one-directional. TSA need not *resolve* every inbound call
+edge; it must never present an unresolved one as a confident absence. A bare
+``caller_count: 0`` over an unresolved edge is the single answer that leads an
+agent to conclude "safe to change" and be wrong.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tree_sitter_analyzer.ast_cache import ASTCache
+from tree_sitter_analyzer.cache.callgraph_state import mark_call_graph_built_strict
+from tree_sitter_analyzer.graph.edge_store import file_node, symbol_node
+from tree_sitter_analyzer.mcp.tools.callers_tool import CodeGraphCallersTool
+
+_TARGET = "target_symbol"
+_OTHER = "other_symbol"
+_RESOLVED = "project"
+
+
+def _insert_call(
+    conn,
+    *,
+    caller: str,
+    caller_line: int,
+    resolution: str,
+    callee: str = _TARGET,
+) -> None:
+    """Insert one CALLS edge with a chosen resolution state.
+
+    ``caller=""`` models a module-level call site: its source is the file node,
+    which is what makes ``caller_name`` empty and the row "unattributed".
+    """
+    source = symbol_node("a.py", caller, caller_line) if caller else file_node("a.py")
+    conn.execute(
+        """INSERT INTO edges
+           (source_node_id, target_node_id, kind, line, provenance, metadata,
+            caller_name, callee_name, file_path, caller_line, callee_full,
+            callee_line, language, callee_resolution, callee_resolved_file)
+           VALUES (?, ?, 'calls', ?, 'tree-sitter', '{}',
+                   ?, ?, 'a.py', ?, ?, 1, 'python', ?, ?)""",
+        (
+            source,
+            symbol_node("a.py", callee, 1),
+            caller_line,
+            caller,
+            callee,
+            caller_line,
+            callee,
+            resolution,
+            "a.py" if resolution == _RESOLVED else "",
+        ),
+    )
+
+
+@pytest.fixture
+def tool_with_edges(tmp_path):
+    """A real cache with the call graph marked built, and its edges cleared."""
+    source = tmp_path / "a.py"
+    source.write_text("def target_symbol():\n    return 1\n", encoding="utf-8")
+    cache = ASTCache(str(tmp_path))
+    assert cache.index_file(str(source))["status"] == "indexed"
+    conn = cache.get_conn()
+    conn.execute("DELETE FROM edges")
+    mark_call_graph_built_strict(conn)
+    conn.commit()
+    try:
+        yield CodeGraphCallersTool(str(tmp_path)), conn
+    finally:
+        cache.close()
+
+
+async def _call(tool) -> dict:
+    return await tool.execute({"function_name": _TARGET, "output_format": "json"})
+
+
+@pytest.mark.asyncio
+async def test_complete_when_every_inbound_edge_resolved(tool_with_edges) -> None:
+    tool, conn = tool_with_edges
+    _insert_call(conn, caller="alpha", caller_line=10, resolution=_RESOLVED)
+    _insert_call(conn, caller="beta", caller_line=20, resolution=_RESOLVED)
+    conn.commit()
+
+    result = await _call(tool)
+
+    assert (result["verdict"], result["completeness"]) == ("INFO", "complete")
+    assert result["unresolved_inbound"] == 0
+
+
+@pytest.mark.asyncio
+async def test_incomplete_when_a_caller_exists_beside_an_unresolved_edge(
+    tool_with_edges,
+) -> None:
+    tool, conn = tool_with_edges
+    _insert_call(conn, caller="alpha", caller_line=10, resolution=_RESOLVED)
+    _insert_call(conn, caller="beta", caller_line=20, resolution="unknown")
+    conn.commit()
+
+    result = await _call(tool)
+
+    # Callers were found, and at least one inbound edge is unresolved, so the
+    # list is a lower bound rather than a census.
+    assert (result["verdict"], result["completeness"]) == ("INFO", "incomplete")
+    assert result["unresolved_inbound"] == 1
+
+
+@pytest.mark.asyncio
+async def test_unknown_never_reports_absence(tool_with_edges) -> None:
+    """The case RFC-0028 §1 names: today's ``NOT_FOUND`` over an unresolved edge."""
+    tool, conn = tool_with_edges
+    _insert_call(conn, caller="", caller_line=0, resolution="unknown")
+    conn.commit()
+
+    result = await _call(tool)
+
+    assert (result["verdict"], result["caller_count"]) == ("NOT_FOUND", 0)
+    assert result["completeness"] == "unknown"
+    # The epistemic status rides beside the existing verdict, which stays legal:
+    # no ninth member is added to a closed cross-surface vocabulary.
+    assert result["verdict"] in {
+        "SAFE", "CAUTION", "UNSAFE", "INFO", "REVIEW", "WARN", "ERROR", "NOT_FOUND",
+    }
+
+    next_step = str(result["next_step"])
+    assert "not in the index" not in next_step
+    assert "unresolved" in next_step
+    assert "not evidence of absence" in result["agent_summary"]["summary_line"]
+
+
+@pytest.mark.asyncio
+async def test_real_zero_is_complete_and_may_say_not_in_index(tool_with_edges) -> None:
+    """A zero over an indexed graph is a fact, and may be stated as one.
+
+    The graph must hold edges somewhere, or the tool answers from parsing rather
+    than from resolved edges and completeness is genuinely unknown.
+    """
+    tool, conn = tool_with_edges
+    _insert_call(conn, caller="alpha", caller_line=10, resolution=_RESOLVED, callee=_OTHER)
+    conn.commit()
+
+    result = await _call(tool)
+
+    assert (result["verdict"], result["completeness"]) == ("NOT_FOUND", "complete")
+    assert "not in the index" in str(result["next_step"])
+    assert result["agent_summary"]["summary_line"] == (
+        f"callers: {_TARGET!r} has 0 caller(s)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_cold_graph_reports_unknown_not_complete(tool_with_edges) -> None:
+    """With no resolved edges at all, a zero is not evidence of absence."""
+    tool, conn = tool_with_edges
+    conn.commit()
+
+    result = await _call(tool)
+
+    assert result["completeness"] == "unknown"
+    assert "not in the index" not in str(result["next_step"])
+
+
+def test_unrecognised_resolution_marker_counts_as_unresolved(tmp_path) -> None:
+    """An unknown marker must degrade toward incomplete, never toward complete.
+
+    The resolution vocabulary is a closed set; a marker this version does not
+    know is not evidence that an edge was resolved.
+    """
+    source = tmp_path / "a.py"
+    source.write_text("def target_symbol():\n    return 1\n", encoding="utf-8")
+    cache = ASTCache(str(tmp_path))
+    try:
+        assert cache.index_file(str(source))["status"] == "indexed"
+        conn = cache.get_conn()
+        conn.execute("DELETE FROM edges")
+        _insert_call(conn, caller="alpha", caller_line=10, resolution="a_future_marker")
+        conn.commit()
+
+        assert cache.count_unresolved_callers(_TARGET) == 1
+    finally:
+        cache.close()

--- a/tests/unit/mcp/tools/test_callers_completeness.py
+++ b/tests/unit/mcp/tools/test_callers_completeness.py
@@ -425,3 +425,73 @@ async def test_dotted_callee_is_judged_by_receiver_not_by_substring(
 
     assert result["unresolved_in_declaring_files"] == 1
     assert result["completeness"] != "complete"
+
+
+def test_declaring_scope_narrows_to_the_named_file() -> None:
+    """Naming a file narrows the §1.2 scope to it; naming nothing keeps all of them.
+
+    Measured before this existed: a symbol declared in both a clean file and a
+    noisy one answered `unknown` for a query that named the clean file, which
+    contradicts §1.2's rule that a symbol in a fully-resolved file answers
+    `complete`. The Windows separator is normalized, and a name that matches no
+    declaring file falls back to every declaring file rather than to silence.
+    """
+    from tree_sitter_analyzer.mcp.tools.callers_tool import _declaring_file_unresolved
+
+    class StubCache:
+        def symbol_declaring_files(self, name: str) -> list[str]:
+            return ["pkg/clean.py", "pkg/noisy.py"]
+
+        def count_unresolved_calls_in_file(self, path: str) -> int:
+            return 0 if path == "pkg/clean.py" else 3
+
+    cache = StubCache()
+    assert _declaring_file_unresolved(cache, "run", None) == 3
+    assert _declaring_file_unresolved(cache, "run", "pkg/clean.py") == 0
+    assert _declaring_file_unresolved(cache, "run", "pkg\\clean.py") == 0
+    assert _declaring_file_unresolved(cache, "run", "pkg/absent.py") == 3
+
+    class FailingCache(StubCache):
+        def symbol_declaring_files(self, name: str) -> None:
+            return None
+
+    # A failed read is not an empty scope: `None`, never 0.
+    assert _declaring_file_unresolved(FailingCache(), "run", None) is None
+
+    class UnreadableFileCache(StubCache):
+        def count_unresolved_calls_in_file(self, path: str) -> None:
+            return None
+
+    # The same rule one level down: one unreadable declaring file makes the whole
+    # count unknown rather than letting the readable siblings stand in for it.
+    assert _declaring_file_unresolved(UnreadableFileCache(), "run", None) is None
+
+
+@pytest.mark.asyncio
+async def test_failed_declaring_read_says_so_instead_of_claiming_a_zero(
+    tool_with_edges, monkeypatch
+) -> None:
+    """A count that could not be read must not be presented as a resolved zero.
+
+    The fail-closed path was asserted in prose but never executed: `completeness`
+    must be `unknown` and the hint must name the unreadable edge rather than
+    allow "not in the index". A resolved edge to another symbol is planted first
+    so the graph holds edges and the empty-evidence branch is not what answers.
+    """
+    tool, conn = tool_with_edges
+    _insert_call(
+        conn, caller="alpha", caller_line=10, resolution=_RESOLVED, callee=_OTHER
+    )
+    conn.commit()
+
+    def _unreadable(self, func_name, file_path=None):
+        return None
+
+    monkeypatch.setattr(ASTCache, "count_unresolved_callers", _unreadable)
+
+    result = await _call(tool)
+
+    assert result["unresolved_inbound"] is None
+    assert result["completeness"] == "unknown"
+    assert "could not be read" in str(result["next_step"])
+    assert "not in the index" not in str(result["next_step"])

--- a/tree_sitter_analyzer/_ast_cache_graph_mixin.py
+++ b/tree_sitter_analyzer/_ast_cache_graph_mixin.py
@@ -214,14 +214,13 @@ class ASTCacheGraphMixin(ASTCacheSurface):
         except sqlite3.OperationalError:
             return None
 
-    def symbol_declaring_files(self, name: str) -> tuple[str, ...]:
-        """Return the files declaring ``name``.
+    def symbol_declaring_files(self, name: str) -> tuple[str, ...] | None:
+        """Return the files declaring ``name``, or ``None`` when unreadable.
 
         Empty is the honest answer for a name this project does not define — a
-        stdlib or framework symbol such as ``SystemExit``.  RFC-0028 §1.2's
-        scope guard is evaluated per declaring file, so a caller with no
-        declaring file falls back to the per-symbol signal alone rather than
-        inventing a scope.
+        stdlib or framework symbol such as ``SystemExit``.  ``None`` is a failed
+        read, and the two must not collapse: a caller reading a failure as an
+        empty scope turns "I could not check" into "nothing unresolved here".
         """
         try:
             rows = self._get_conn().execute(
@@ -229,7 +228,7 @@ class ASTCacheGraphMixin(ASTCacheSurface):
                 (name,),
             ).fetchall()
         except sqlite3.OperationalError:
-            return ()
+            return None
         return tuple(str(row[0]) for row in rows if row[0])
 
     def call_graph_built(self) -> bool:

--- a/tree_sitter_analyzer/_ast_cache_graph_mixin.py
+++ b/tree_sitter_analyzer/_ast_cache_graph_mixin.py
@@ -178,6 +178,26 @@ class ASTCacheGraphMixin(ASTCacheSurface):
         except sqlite3.OperationalError:
             return False
 
+    def count_unresolved_callers(
+        self,
+        callee_name: str,
+        callee_file: str | None = None,
+    ) -> int | None:
+        """Count in-scope CALLS edges into ``callee_name`` not known resolved.
+
+        Returns ``None`` when the count cannot be read.  ``None`` is not ``0``:
+        a failed read must not become a confident "every edge is resolved", so
+        callers treat it as unknown rather than complete.
+        """
+        try:
+            from .graph.edge_store import EdgeStore
+
+            return EdgeStore(
+                self._get_conn(), ensure_schema=False
+            ).count_unresolved_callers(callee_name, callee_file)
+        except sqlite3.OperationalError:
+            return None
+
     def call_graph_built(self) -> bool:
         """Return whether a completed call-graph build is recorded."""
         return _call_graph_built(self._get_conn())

--- a/tree_sitter_analyzer/_ast_cache_graph_mixin.py
+++ b/tree_sitter_analyzer/_ast_cache_graph_mixin.py
@@ -198,6 +198,40 @@ class ASTCacheGraphMixin(ASTCacheSurface):
         except sqlite3.OperationalError:
             return None
 
+    def count_unresolved_calls_in_file(self, file_path: str) -> int | None:
+        """Count unresolved CALLS edges originating in ``file_path``.
+
+        Returns ``None`` when the count cannot be read, for the same reason
+        :meth:`count_unresolved_callers` does: a failed read must not read as
+        "no unresolved call here".
+        """
+        try:
+            from .graph.edge_store import EdgeStore
+
+            return EdgeStore(
+                self._get_conn(), ensure_schema=False
+            ).count_unresolved_calls_in_file(file_path)
+        except sqlite3.OperationalError:
+            return None
+
+    def symbol_declaring_files(self, name: str) -> tuple[str, ...]:
+        """Return the files declaring ``name``.
+
+        Empty is the honest answer for a name this project does not define — a
+        stdlib or framework symbol such as ``SystemExit``.  RFC-0028 §1.2's
+        scope guard is evaluated per declaring file, so a caller with no
+        declaring file falls back to the per-symbol signal alone rather than
+        inventing a scope.
+        """
+        try:
+            rows = self._get_conn().execute(
+                "SELECT DISTINCT file_path FROM ast_symbol_rows WHERE name = ?",
+                (name,),
+            ).fetchall()
+        except sqlite3.OperationalError:
+            return ()
+        return tuple(str(row[0]) for row in rows if row[0])
+
     def call_graph_built(self) -> bool:
         """Return whether a completed call-graph build is recorded."""
         return _call_graph_built(self._get_conn())

--- a/tree_sitter_analyzer/graph/edge_store.py
+++ b/tree_sitter_analyzer/graph/edge_store.py
@@ -459,6 +459,24 @@ class EdgeStore:
                 count += 1
         return count
 
+    def count_unresolved_calls_in_file(self, file_path: str) -> int:
+        """Count unresolved CALLS edges originating in ``file_path``.
+
+        A computed callee is recorded under its source text — ``HANDLERS[name]``,
+        ``getattr(self, name)`` — so the row names no symbol and a per-symbol
+        lookup cannot see it. Asking the declaring file instead is what makes
+        RFC-0028 §1.2's scope guard decidable: an unresolved call inside a file
+        may target anything that file declares.
+        """
+        resolved = sorted(_RESOLVED_CALLEE_RESOLUTIONS)
+        placeholders = ", ".join("?" for _ in resolved)
+        row = self._conn.execute(
+            f"SELECT COUNT(*) FROM edges WHERE kind = ? AND file_path = ? "
+            f"AND callee_resolution NOT IN ({placeholders})",
+            (EdgeKind.CALLS.value, file_path, *resolved),
+        ).fetchone()
+        return int(row[0]) if row is not None else 0
+
     def query_callees(
         self,
         caller_name: str,

--- a/tree_sitter_analyzer/graph/edge_store.py
+++ b/tree_sitter_analyzer/graph/edge_store.py
@@ -7,6 +7,7 @@ The store is intentionally small and dependency-light: it is used by
 from __future__ import annotations
 
 import json
+import re
 import sqlite3
 from collections import deque
 from dataclasses import dataclass, field
@@ -441,21 +442,25 @@ class EdgeStore:
         callee_name: str,
         callee_file: str | None = None,
     ) -> int:
-        """Count in-scope CALLS edges into ``callee_name`` not known resolved.
+        """Count inbound CALLS edges into ``callee_name`` not known resolved.
 
-        Selects through ``_direct_callers``, the same path the caller list uses,
-        so a caller list and its completeness cannot disagree about which edges
-        are in scope.  ``callee_name`` resolution is read from the edge's
-        ``callee_resolution`` scalar; see ``_RESOLVED_CALLEE_RESOLUTIONS`` for
-        why an unrecognised value counts as unresolved.
+        This is deliberately **not** the set of listed callers.  The list is
+        assembled by ``query_callers`` (``_bfs_call_edges``) and then deduplicated
+        by caller file/name/line with module-level sites removed; this counts raw
+        inbound edges through ``_direct_callers``, module-level rows included.
+        The two answer different questions — how many call sites were listed,
+        versus how many edges into the symbol stayed unresolved — so a
+        ``caller_count`` of 0 beside a non-zero count here is the intended
+        reading rather than a contradiction; a module-level site is the ordinary
+        way that happens.  No duplicate can inflate the count, because ``edges``
+        is UNIQUE over ``(source_node_id, target_node_id, kind, line)``.
+        Resolution is read through ``_resolution_is_resolved``; see
+        ``_RESOLVED_CALLEE_RESOLUTIONS`` for why an unrecognised value counts as
+        unresolved.
         """
         count = 0
         for row in _direct_callers(self._conn, callee_name, callee_file):
-            edge = _edge_from_row(row)
-            resolution = str(
-                _row_col(row, "callee_resolution", "callee_resolution", edge) or ""
-            )
-            if resolution not in _RESOLVED_CALLEE_RESOLUTIONS:
+            if not _resolution_is_resolved(row):
                 count += 1
         return count
 
@@ -467,15 +472,32 @@ class EdgeStore:
         lookup cannot see it. Asking the declaring file instead is what makes
         RFC-0028 §1.2's scope guard decidable: an unresolved call inside a file
         may target anything that file declares.
+
+        Reads through ``_resolution_is_resolved``, the same predicate
+        ``count_unresolved_callers`` uses.  A raw ``NOT IN`` over the column alone
+        could disagree with that predicate on rows whose marker lives in the
+        metadata JSON, which would let the two numbers the response reports side
+        by side describe different edge sets.  Rows are therefore read rather than
+        aggregated; the alternative requires reproducing the metadata fallback in
+        SQL, and a per-file edge count is small enough that the loop is not the
+        cost that matters.
+
+        Only edges that could name a file-local symbol are counted;
+        ``_can_target_local_symbol`` records why, and measured why it matters.
         """
-        resolved = sorted(_RESOLVED_CALLEE_RESOLUTIONS)
-        placeholders = ", ".join("?" for _ in resolved)
-        row = self._conn.execute(
-            f"SELECT COUNT(*) FROM edges WHERE kind = ? AND file_path = ? "
-            f"AND callee_resolution NOT IN ({placeholders})",
-            (EdgeKind.CALLS.value, file_path, *resolved),
-        ).fetchone()
-        return int(row[0]) if row is not None else 0
+        rows = self._conn.execute(
+            "SELECT * FROM edges WHERE kind = ? AND file_path = ?",
+            (EdgeKind.CALLS.value, file_path),
+        ).fetchall()
+        count = 0
+        for row in rows:
+            if _resolution_is_resolved(row):
+                continue
+            edge = _edge_from_row(row)
+            callee_full = str(_row_col(row, "callee_full", "callee_full", edge) or "")
+            if _can_target_local_symbol(callee_full):
+                count += 1
+        return count
 
     def query_callees(
         self,
@@ -797,7 +819,85 @@ def _row_col(row: sqlite3.Row, column: str, meta_key: str, edge: Edge) -> Any:
 # resolved".  Degrading an unrecognised marker toward "incomplete" is the safe
 # direction — reporting a complete caller list over an unresolved edge is the
 # error a caller cannot detect.
-_RESOLVED_CALLEE_RESOLUTIONS = frozenset({"project", "builtin", "stdlib", "local"})
+#
+# 'external' is listed because it is a *terminal* resolution, not an unknown one:
+# the callee was resolved to a symbol outside the project.  `synapse.py` relies
+# on exactly that distinction when it refuses to re-scan edges already marked
+# ('external', 'stdlib') — "target lives outside the project, no resolved_file
+# by design".  Omitting it made this reader disagree with that writer about a
+# finished edge: measured on the 2,174-file self-repo corpus, 4,247 CALLS rows
+# (2.58%) carry it, and counting them as unresolved gated 1,562 files instead of
+# 1,363, barring every symbol they declare from answering `complete`.  The
+# inversion above still covers genuinely unrecognised markers; this set lists the
+# markers the writer treats as final.
+_RESOLVED_CALLEE_RESOLUTIONS = frozenset(
+    {"project", "builtin", "stdlib", "local", "external"}
+)
+
+
+def _resolution_is_resolved(row: sqlite3.Row) -> bool:
+    """Whether an edge row's ``callee_resolution`` establishes its callee.
+
+    The single reader behind every completeness count.  The marker is read
+    through ``_row_col``, which falls back to the metadata JSON for rows written
+    by a schema that kept it there; aggregating the column in SQL instead
+    disagrees with that fallback on exactly those rows, which is how a caller
+    list and its completeness could describe different edge sets.
+    """
+    edge = _edge_from_row(row)
+    resolution = str(
+        _row_col(row, "callee_resolution", "callee_resolution", edge) or ""
+    )
+    return resolution in _RESOLVED_CALLEE_RESOLUTIONS
+
+
+#: Receiver names whose attribute calls cannot reach a symbol the scanning file
+#: declares.  `list.append`, `dict.get`, `set.add`, `super().__init__` — the
+#: attribute belongs to a builtin type, not to anything the project defines.
+_BUILTIN_RECEIVERS = frozenset(
+    {
+        "list",
+        "dict",
+        "set",
+        "frozenset",
+        "tuple",
+        "str",
+        "bytes",
+        "bytearray",
+        "int",
+        "float",
+        "bool",
+        "complex",
+        "object",
+        "type",
+        "super",
+    }
+)
+
+#: ``<name>.<attribute>`` or ``<name>().<attribute>`` and nothing else.
+#: Deliberately strict.  A looser "text before the first dot" reading would take
+#: the receiver of ``getattr(importlib.import_module(m), cls).x`` to be
+#: ``getattr(importlib`` and could excuse a genuine dispatch site, and
+#: ``handlers["read"]`` has no receiver text at all.
+_DOTTED_CALLEE = re.compile(
+    r"^([A-Za-z_][A-Za-z0-9_]*)(?:\(\))?\.([A-Za-z_][A-Za-z0-9_]*)$"
+)
+
+
+def _can_target_local_symbol(callee_full: str) -> bool:
+    """Whether an unresolved call with this callee could name a file-local symbol.
+
+    Conservative by construction: only a dotted callee whose receiver is a
+    builtin type name is ruled out.  Bare names, ``self.``/``cls.``, computed
+    dispatch (``handlers["read"]``), ``getattr(...)``, and any receiver that is a
+    local variable all stay counted, because each may name something the file
+    declares.  Over-counting only holds a symbol at ``incomplete``; under-counting
+    would certify absence over a real edge, the one direction RFC-0028 §1 forbids.
+    """
+    match = _DOTTED_CALLEE.match(callee_full or "")
+    if match is None:
+        return True
+    return match.group(1) not in _BUILTIN_RECEIVERS
 
 
 def _matches_callee(row: sqlite3.Row, target: NodeRef, callee_name: str) -> bool:

--- a/tree_sitter_analyzer/graph/edge_store.py
+++ b/tree_sitter_analyzer/graph/edge_store.py
@@ -436,6 +436,29 @@ class EdgeStore:
             direction="callers",
         )
 
+    def count_unresolved_callers(
+        self,
+        callee_name: str,
+        callee_file: str | None = None,
+    ) -> int:
+        """Count in-scope CALLS edges into ``callee_name`` not known resolved.
+
+        Selects through ``_direct_callers``, the same path the caller list uses,
+        so a caller list and its completeness cannot disagree about which edges
+        are in scope.  ``callee_name`` resolution is read from the edge's
+        ``callee_resolution`` scalar; see ``_RESOLVED_CALLEE_RESOLUTIONS`` for
+        why an unrecognised value counts as unresolved.
+        """
+        count = 0
+        for row in _direct_callers(self._conn, callee_name, callee_file):
+            edge = _edge_from_row(row)
+            resolution = str(
+                _row_col(row, "callee_resolution", "callee_resolution", edge) or ""
+            )
+            if resolution not in _RESOLVED_CALLEE_RESOLUTIONS:
+                count += 1
+        return count
+
     def query_callees(
         self,
         caller_name: str,
@@ -748,6 +771,15 @@ def _row_col(row: sqlite3.Row, column: str, meta_key: str, edge: Edge) -> Any:
         if meta_value not in (None, "", 0):
             return meta_value
     return value
+
+
+# Resolutions that establish an edge's callee.  The set is inverted on purpose:
+# the schema default ('unknown'), the second pass's 'unresolved_refs'
+# placeholder, and any marker a later version adds all read as "not known to be
+# resolved".  Degrading an unrecognised marker toward "incomplete" is the safe
+# direction — reporting a complete caller list over an unresolved edge is the
+# error a caller cannot detect.
+_RESOLVED_CALLEE_RESOLUTIONS = frozenset({"project", "builtin", "stdlib", "local"})
 
 
 def _matches_callee(row: sqlite3.Row, target: NodeRef, callee_name: str) -> bool:

--- a/tree_sitter_analyzer/mcp/tools/callers_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/callers_tool.py
@@ -32,7 +32,6 @@ def _declaring_file_unresolved(
     cache: Any,
     func_name: str,
     file_path: str | None,
-    data_source: str,
 ) -> int | None:
     """Unresolved CALLS edges inside the files that declare ``func_name``.
 
@@ -50,8 +49,15 @@ def _declaring_file_unresolved(
 
     ``None`` means the question could not be answered — including a failed read of
     the declaring files, which must never degrade to "nothing unresolved here".
+
+    This reads the cache directly and is therefore answerable on every data
+    source, not only the SQL one.  Gating it on ``data_source == "sql"`` returned
+    ``None`` for a query that took the in-memory graph path, which the caller then
+    reported as "its inbound edges could not be read" — a claim of ignorance where
+    the answer was available, and measured to mislabel a genuinely absent symbol
+    as an unreadable one.
     """
-    if cache is None or data_source != "sql":
+    if cache is None:
         return None
     declaring = cache.symbol_declaring_files(func_name)
     if declaring is None:
@@ -216,6 +222,13 @@ class CodeGraphCallersTool(CodeGraphRelationToolMixin, BaseMCPTool):
                 cache is not None and cache.has_call_edges()
             )
 
+        # A graph that holds no CALLS edges at all cannot support an absence
+        # claim: a zero read from it is indistinguishable from a graph that was
+        # never populated.  This is the counterpart of `has_any_call_edges`
+        # above, which trusts the marker; here the marker may be set over an
+        # empty table, so the edge probe itself is the evidence.
+        empty_evidence_base = cache is not None and not cache.has_call_edges()
+
         warnings_list: list[str] = []
         if _is_stale_resolution(callers):
             warnings_list.append(_STALE_CACHE_WARNING)
@@ -236,7 +249,7 @@ class CodeGraphCallersTool(CodeGraphRelationToolMixin, BaseMCPTool):
         # unknown, never complete — a failed read is not evidence of absence.
         unresolved_inbound = (
             cache.count_unresolved_callers(func_name, file_path)
-            if cache is not None and data_source == "sql"
+            if cache is not None
             else None
         )
         # RFC-0028 §1.2 scope guard.  A computed dispatch site is recorded under
@@ -246,7 +259,7 @@ class CodeGraphCallersTool(CodeGraphRelationToolMixin, BaseMCPTool):
         # claim is gated on the declaring files as well.  A symbol in a
         # fully-resolved file still answers complete.
         unresolved_in_declaring_files = _declaring_file_unresolved(
-            cache, func_name, file_path, data_source
+            cache, func_name, file_path
         )
 
         if unresolved_inbound is None or unresolved_in_declaring_files is None:
@@ -261,6 +274,13 @@ class CodeGraphCallersTool(CodeGraphRelationToolMixin, BaseMCPTool):
             # two resolved module-level callers, which reported `complete` with
             # `caller_count: 0` and "not in the index".
             completeness = "incomplete"
+        elif empty_evidence_base:
+            # Zero unresolved edges over a graph that holds no CALLS edges at all
+            # is not a fact about this symbol: the resolved-edge evidence base is
+            # empty, so a zero read from it cannot distinguish "nothing calls this"
+            # from "the graph was never populated".  A zero over a graph that holds
+            # edges elsewhere is a fact and still answers complete.
+            completeness = "unknown"
         else:
             completeness = "complete"
 
@@ -328,6 +348,18 @@ class CodeGraphCallersTool(CodeGraphRelationToolMixin, BaseMCPTool):
                         f"in a file that declares {func_name!r} and could target "
                         "it. Resolve them or read those sites directly rather "
                         "than treating this as absence."
+                    )
+                elif empty_evidence_base:
+                    # #705: an index that was built over a project with no calls
+                    # must not be told to --full-index again.  The user already
+                    # indexed; the graph is simply empty.  What must not happen
+                    # is a confident absence, so the hint disclaims rather than
+                    # instructs.
+                    index_hint = (
+                        f"No resolved caller for {func_name!r}, and the call graph "
+                        "holds no call edges at all. An empty graph cannot "
+                        "distinguish 'nothing calls it' from 'never populated', "
+                        "so do not treat this as absence."
                     )
                 else:
                     index_hint = (

--- a/tree_sitter_analyzer/mcp/tools/callers_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/callers_tool.py
@@ -28,6 +28,36 @@ from .index_rebuild_signal import (
 logger = setup_logger(__name__)
 
 
+def _declaring_file_unresolved(
+    cache: Any,
+    func_name: str,
+    data_source: str,
+) -> int | None:
+    """Unresolved CALLS edges inside the files that declare ``func_name``.
+
+    The RFC-0028 §1.2 scope guard: a computed dispatch site records its own
+    source text as the callee, so no per-symbol lookup can see it, and the only
+    place it can be counted from is the file it sits in.  A symbol with no
+    declaring file in this project contributes ``0`` — there is no file scope to
+    check, which is different from a scope that could not be read.
+
+    ``None`` means the question could not be answered at all; it must never read
+    as "nothing unresolved here".
+    """
+    if cache is None or data_source != "sql":
+        return None
+    declaring = cache.symbol_declaring_files(func_name)
+    if not declaring:
+        return 0
+    total = 0
+    for path in declaring:
+        count = cache.count_unresolved_calls_in_file(path)
+        if count is None:
+            return None
+        total += count
+    return total
+
+
 class CodeGraphCallersTool(CodeGraphRelationToolMixin, BaseMCPTool):
     """MCP Tool for finding callers of a function (CodeGraph parity)."""
 
@@ -192,9 +222,19 @@ class CodeGraphCallersTool(CodeGraphRelationToolMixin, BaseMCPTool):
             if cache is not None and data_source == "sql"
             else None
         )
-        if unresolved_inbound is None:
+        # RFC-0028 §1.2 scope guard.  A computed dispatch site is recorded under
+        # its source text (`HANDLERS[name]`, `getattr(self, name)`), so it names
+        # no symbol and the per-symbol count above cannot see it.  An unresolved
+        # call inside a file that declares this symbol could target it, so the
+        # claim is gated on the declaring files as well.  A symbol in a
+        # fully-resolved file still answers complete.
+        unresolved_in_declaring_files = _declaring_file_unresolved(
+            cache, func_name, data_source
+        )
+
+        if unresolved_inbound is None or unresolved_in_declaring_files is None:
             completeness = "unknown"
-        elif unresolved_inbound == 0:
+        elif unresolved_inbound + unresolved_in_declaring_files == 0:
             completeness = "complete"
         elif total_callers:
             completeness = "incomplete"
@@ -212,6 +252,7 @@ class CodeGraphCallersTool(CodeGraphRelationToolMixin, BaseMCPTool):
             truncated=truncated,
             completeness=completeness,
             unresolved_inbound=unresolved_inbound,
+            unresolved_in_declaring_files=unresolved_in_declaring_files,
             callers=callers,
         )
         if unattributed_call_sites:

--- a/tree_sitter_analyzer/mcp/tools/callers_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/callers_tool.py
@@ -31,22 +31,39 @@ logger = setup_logger(__name__)
 def _declaring_file_unresolved(
     cache: Any,
     func_name: str,
+    file_path: str | None,
     data_source: str,
 ) -> int | None:
     """Unresolved CALLS edges inside the files that declare ``func_name``.
 
     The RFC-0028 §1.2 scope guard: a computed dispatch site records its own
     source text as the callee, so no per-symbol lookup can see it, and the only
-    place it can be counted from is the file it sits in.  A symbol with no
-    declaring file in this project contributes ``0`` — there is no file scope to
-    check, which is different from a scope that could not be read.
+    place it can be counted from is the file it sits in.  A symbol this project
+    does not declare contributes ``0`` — there is no file scope to check, which is
+    different from a scope that could not be read.
 
-    ``None`` means the question could not be answered at all; it must never read
-    as "nothing unresolved here".
+    ``file_path`` narrows the scope when the caller named one.  Without it, a
+    symbol declared in several files inherits every sibling's unresolved calls:
+    measured, `run` declared in a clean file and a noisy one answered `unknown`
+    for a query that named the clean file, contradicting §1.2's guard that a
+    symbol in a fully-resolved file answers ``complete``.
+
+    ``None`` means the question could not be answered — including a failed read of
+    the declaring files, which must never degrade to "nothing unresolved here".
     """
     if cache is None or data_source != "sql":
         return None
     declaring = cache.symbol_declaring_files(func_name)
+    if declaring is None:
+        # A failed read is not an empty scope; the sibling count method returns
+        # None for exactly this reason.
+        return None
+    if file_path:
+        normalized = file_path.replace("\\", "/")
+        narrowed = tuple(
+            path for path in declaring if path.replace("\\", "/") == normalized
+        )
+        declaring = narrowed or declaring
     if not declaring:
         return 0
     total = 0
@@ -229,17 +246,23 @@ class CodeGraphCallersTool(CodeGraphRelationToolMixin, BaseMCPTool):
         # claim is gated on the declaring files as well.  A symbol in a
         # fully-resolved file still answers complete.
         unresolved_in_declaring_files = _declaring_file_unresolved(
-            cache, func_name, data_source
+            cache, func_name, file_path, data_source
         )
 
         if unresolved_inbound is None or unresolved_in_declaring_files is None:
             completeness = "unknown"
-        elif unresolved_inbound + unresolved_in_declaring_files == 0:
-            completeness = "complete"
-        elif total_callers:
+        elif unresolved_inbound + unresolved_in_declaring_files:
+            completeness = "incomplete" if total_callers else "unknown"
+        elif unattributed_call_sites:
+            # #638 counts module-level call sites instead of listing them, so a
+            # listed count of 0 is not a census: the symbol *is* called and this
+            # response cannot say by whom.  Certifying "complete" over that is the
+            # false zero RFC-0028 §1 exists to forbid — measured on a symbol with
+            # two resolved module-level callers, which reported `complete` with
+            # `caller_count: 0` and "not in the index".
             completeness = "incomplete"
         else:
-            completeness = "unknown"
+            completeness = "complete"
 
         result = build_response(
             verdict="INFO" if callers or total_callers else "NOT_FOUND",
@@ -281,15 +304,30 @@ class CodeGraphCallersTool(CodeGraphRelationToolMixin, BaseMCPTool):
                     "Run `tree-sitter-analyzer --full-index` first, then retry."
                 )
             elif completeness != "complete":
-                # "Not in the index" may only describe a genuine absence.  An
-                # unresolved inbound edge means this symbol may still be
-                # called, so name the unresolved edges instead (RFC-0028 §1.1).
+                # "Not in the index" may only describe a genuine absence.  Name
+                # the reason the list is not a census instead (RFC-0028 §1.1,
+                # §1.2).  A successfully-read 0 is not a failure to read, so the
+                # branches test `is None` rather than truthiness.
                 if unresolved_inbound:
                     index_hint = (
                         f"No resolved caller for {func_name!r}, and "
                         f"{unresolved_inbound} call edge(s) into it are "
                         "unresolved, so it may still be called. Read those call "
                         "sites directly rather than treating this as absence."
+                    )
+                elif unattributed_call_sites:
+                    index_hint = (
+                        f"{unattributed_call_sites} module-level call site(s) "
+                        f"reach {func_name!r}. They have no enclosing function "
+                        "and are counted rather than listed, so this is not an "
+                        "empty result; read them directly."
+                    )
+                elif unresolved_in_declaring_files:
+                    index_hint = (
+                        f"{unresolved_in_declaring_files} unresolved call(s) sit "
+                        f"in a file that declares {func_name!r} and could target "
+                        "it. Resolve them or read those sites directly rather "
+                        "than treating this as absence."
                     )
                 else:
                     index_hint = (
@@ -308,15 +346,21 @@ class CodeGraphCallersTool(CodeGraphRelationToolMixin, BaseMCPTool):
         # #546 seam 3 / #577 leftover: uniform agent_summary across all nav actions.
         verdict = result.get("verdict", "NOT_FOUND")
         if verdict == "NOT_FOUND":
-            # A zero is a fact only when every inbound edge resolved; otherwise
-            # the summary must not restate the absence the verdict already
-            # implies (RFC-0028 §1.1).
-            as_summary_line = (
-                f"callers: {func_name!r} has 0 caller(s)"
-                if completeness == "complete"
-                else f"callers: {func_name!r} has 0 resolved caller(s); "
-                "this is not evidence of absence"
-            )
+            # A zero is a fact only when every inbound edge resolved *and* every
+            # caller could be listed; otherwise the summary must not restate the
+            # absence the verdict already implies (RFC-0028 §1.1, §1.2).
+            if completeness == "complete":
+                as_summary_line = f"callers: {func_name!r} has 0 caller(s)"
+            elif unattributed_call_sites:
+                as_summary_line = (
+                    f"callers: {func_name!r} has 0 listed caller(s) but "
+                    f"{unattributed_call_sites} module-level call site(s)"
+                )
+            else:
+                as_summary_line = (
+                    f"callers: {func_name!r} has 0 resolved caller(s); "
+                    "this is not evidence of absence"
+                )
             as_next_step = result.get("next_step") or (
                 f"No callers found for '{func_name}'. "
                 "Check spelling or run --full-index to build the call graph."

--- a/tree_sitter_analyzer/mcp/tools/callers_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/callers_tool.py
@@ -183,6 +183,24 @@ class CodeGraphCallersTool(CodeGraphRelationToolMixin, BaseMCPTool):
         # agent answers from content, not coordinates — no Read per file:line.
         next_step = self._inline_caller_bodies(cache, callers)
 
+        # RFC-0028 §1.1: declare the epistemic status of this list.  It is
+        # assembled from resolved CALLS edges, so an unresolved inbound edge
+        # makes it a lower bound rather than a census.  An unreadable count is
+        # unknown, never complete — a failed read is not evidence of absence.
+        unresolved_inbound = (
+            cache.count_unresolved_callers(func_name, file_path)
+            if cache is not None and data_source == "sql"
+            else None
+        )
+        if unresolved_inbound is None:
+            completeness = "unknown"
+        elif unresolved_inbound == 0:
+            completeness = "complete"
+        elif total_callers:
+            completeness = "incomplete"
+        else:
+            completeness = "unknown"
+
         result = build_response(
             verdict="INFO" if callers or total_callers else "NOT_FOUND",
             warnings=warnings_list or None,
@@ -192,6 +210,8 @@ class CodeGraphCallersTool(CodeGraphRelationToolMixin, BaseMCPTool):
             callers_listed=len(callers),
             listed_cap=listed_cap,
             truncated=truncated,
+            completeness=completeness,
+            unresolved_inbound=unresolved_inbound,
             callers=callers,
         )
         if unattributed_call_sites:
@@ -219,6 +239,22 @@ class CodeGraphCallersTool(CodeGraphRelationToolMixin, BaseMCPTool):
                     "Call-graph index is empty or has not been built yet. "
                     "Run `tree-sitter-analyzer --full-index` first, then retry."
                 )
+            elif completeness != "complete":
+                # "Not in the index" may only describe a genuine absence.  An
+                # unresolved inbound edge means this symbol may still be
+                # called, so name the unresolved edges instead (RFC-0028 §1.1).
+                if unresolved_inbound:
+                    index_hint = (
+                        f"No resolved caller for {func_name!r}, and "
+                        f"{unresolved_inbound} call edge(s) into it are "
+                        "unresolved, so it may still be called. Read those call "
+                        "sites directly rather than treating this as absence."
+                    )
+                else:
+                    index_hint = (
+                        f"No resolved caller for {func_name!r} and its inbound "
+                        "edges could not be read. Do not treat this as absence."
+                    )
             else:
                 index_hint = (
                     f"Symbol {func_name!r} not in the index. "
@@ -231,7 +267,15 @@ class CodeGraphCallersTool(CodeGraphRelationToolMixin, BaseMCPTool):
         # #546 seam 3 / #577 leftover: uniform agent_summary across all nav actions.
         verdict = result.get("verdict", "NOT_FOUND")
         if verdict == "NOT_FOUND":
-            as_summary_line = f"callers: {func_name!r} has 0 caller(s)"
+            # A zero is a fact only when every inbound edge resolved; otherwise
+            # the summary must not restate the absence the verdict already
+            # implies (RFC-0028 §1.1).
+            as_summary_line = (
+                f"callers: {func_name!r} has 0 caller(s)"
+                if completeness == "complete"
+                else f"callers: {func_name!r} has 0 resolved caller(s); "
+                "this is not evidence of absence"
+            )
             as_next_step = result.get("next_step") or (
                 f"No callers found for '{func_name}'. "
                 "Check spelling or run --full-index to build the call graph."


### PR DESCRIPTION
Implements the surface half of RFC-0028 §1.1: the callers response now declares its own completeness, and `next_step` may only claim absence when every inbound edge resolved. No ninth verdict.

## The problem, restated as the RFC states it

An empty caller list is not evidence that nothing calls a symbol. Four states existed in the data and only one answer was emitted: `NOT_FOUND` with `count: 0`, which reads as "safe to change". The RFC's rule is one-directional — TSA need not *resolve* every edge, it must not *present* an unresolved one as absence.

## Design

`completeness: "complete" | "incomplete" | "unknown"` rides beside the verdict:

| state | meaning |
|---|---|
| `complete` | every inbound edge resolved; a `caller_count` of 0 is a real zero |
| `incomplete` | callers were found **and** at least one inbound edge is unresolved; the list is a lower bound |
| `unknown` | no caller was listed **and** at least one inbound edge is unresolved |

The verdict vocabulary is untouched. `_LEGAL_VERDICTS` is a closed cross-surface contract pinned in two places, and widening it would force every consumer's branch table to change; an orthogonal field leaves every existing branch correct.

Two decisions worth review:

- **The count selects through `_direct_callers`** — the same function that builds the caller list — so a list and its completeness cannot disagree about which edges are in scope. This is load-bearing: an independent query would let `caller_count: 5` coexist with `completeness: complete` while an unresolved sixth edge existed.
- **The resolved set is inverted.** `_RESOLVED_CALLEE_RESOLUTIONS = {project, builtin, stdlib, local}`; anything else counts as unresolved, so the schema default, the second pass's `unresolved_refs` placeholder, and any marker a later version adds all degrade toward `incomplete`. Claiming a complete list over an unresolved edge is the error a caller cannot detect, so the safe direction is the over-cautious one.

An unreadable count returns `None` rather than `0`, and `None` maps to `unknown` — a failed read is not evidence of absence.

## Evidence

Measured on this repository's own source (903 files, 50,528 CALLS edges), which is why the field is not degenerate:

| `callee_resolution` | edges |
|---|---:|
| `project` / `builtin` / `stdlib` / `local` | 15,012 / 12,168 / 9,396 / 9,011 |
| `unknown` (unresolved) | 4,941 |

Only **549 of 7,176** distinct callee names have any unresolved inbound edge, so `complete` is the normal answer and the other two states are a meaningful minority. The three-state split over that corpus is 6,627 complete / 110 incomplete / 439 names with unresolved-only edges.

`unknown` is reachable in the way the RFC describes — through module-level call sites, which have no enclosing function and are counted rather than listed. Verified end-to-end on the indexed corpus:

```
SystemExit       verdict=NOT_FOUND count=0 completeness='unknown'    unresolved=2
writeText        verdict=NOT_FOUND count=0 completeness='unknown'    unresolved=1
setInterval      verdict=NOT_FOUND count=0 completeness='unknown'    unresolved=1
getElementById   verdict=NOT_FOUND count=0 completeness='unknown'    unresolved=1
Parser           verdict=INFO      count=50 completeness='incomplete' unresolved=2
ASTCache         verdict=INFO      count=56 completeness='complete'   unresolved=0
```

For `SystemExit`, the RFC's exact case: `next_step` no longer says "not in the index", it names the 2 unresolved edges, and `agent_summary.summary_line` reads *"has 0 resolved caller(s); this is not evidence of absence"*. Both surfaces emit the field — `tsa --callers SystemExit --format json` carries `completeness`, and on a cold graph it reports `unknown` rather than the old implied zero.

## Verification

- `tests/unit/mcp/tools/test_callers_completeness.py` — 6 new tests: each state, the `unknown`-never-reports-absence invariant, that a real zero still may say "not in the index", that a cold graph is `unknown` not `complete`, and that an unrecognised resolution marker counts as unresolved.
- `pytest` over the contract, nav-facade, edge-store and CLI↔MCP parity suites → **189 passed** (includes `_N_VERDICT_VOCABULARY` and `test_registered_mcp_tools_have_cli_parity`).
- `ruff check` clean.
- RFC-0028's three §1.1 acceptance boxes are now checked; the §1 corpus, the CI ratchet, and the §1.2 reconciliation are **not** — see below.

## Not in this PR

The RFC requires a hand-checked corpus of genuinely undecidable edges (dynamic dispatch, string-keyed invocation, reflection, decorator registration) plus a ratchet wired into a **named** CI job with its marker set recorded and a proven non-zero collected count. That is the test half of §1 and it is not faked here by promoting six fixture tests into its place. §1.2's reconciliation with `test_unknown_rate_ratchet.py` is likewise untouched.


---

**Reopened as a new PR after a branch rename.** The gitflow guard
(`Validate head→base per GITFLOW.md`) correctly rejected `rfc-0028-callers-completeness`:
PRs to `develop` must use a GitFlow prefix (`feature/*`, `fix/*`, `test/*`, …), and that
name matched none of them. GitHub's rename endpoint closes the PR rather than
retargeting it, so this is the same commit (`d2224216`) under `feature/rfc-0028-callers-completeness`.
No content changed. See the follow-up comment at the end of the predecessor for the
four correctness fixes landed after the original body was written.
