### PR TITLE
test(rfc-0028): gate next_step routability, and make "removed" checkable

### DIFF
--- a/rfcs/0028-measuring-claimed-properties.md
+++ b/rfcs/0028-measuring-claimed-properties.md
@@ -396,9 +396,21 @@ asked:
    > Any `next_step` containing a token matching a known tool / facade / action
    > name must resolve to a **registered** route.
 
-   That still catches the live defect: `build_project_index_tool.py` emits
-   `next_step="get_project_summary"`, a token that matches a tool name and
-   resolves nowhere.
+   That formulation still catches the class this section records. *Measured
+   correction (2026-09-12).* The defect named here has since been fixed, and was
+   mis-located: `get_project_summary` is back in `facade_map.LEGACY_TOOL_MAP`
+   (resolving to `project action=card`), and its mention in
+   `build_project_index_tool.py` is inside the tool **description**, not a
+   `next_step`. So the live instance is gone; the class is not.
+
+   The gate that covers it (`tests/unit/mcp/test_next_step_routability.py`)
+   harvests `next_step` string constants by AST and resolves every token that
+   collides with a published name. Measuring it exposed the class this section's
+   wording cannot reach: a name a breaking change **removed** resolves nowhere by
+   construction, so a vocabulary of currently-resolving names cannot see it.
+   `facade_map.REMOVED_TOOL_NAMES` is what makes "removed" machine-checkable, and
+   injecting `search_content` into a `next_step` now fails the gate rather than
+   being silently skipped.
 3. **Dispatch reachability.** For each language-family branch in a resolver
    dispatch, at least one test must reach it **through the public entry point**,
    not by calling the private helper. *This catches defect #3, where the ESM
@@ -658,7 +670,11 @@ rather than dropping it.
    empty must fail the gate.
 3. §3.1: RED today — the registered-surface invariant must fail on the known
    orphan before the orphan is wired.
-4. §3.1: `next_step` routability must fail today on the known unroutable string.
+4. §3.1: `next_step` routability must fail on an unroutable token. RED-first was
+   not available here: the string this item named is fixed, and no unroutable
+   token remains in the tree. The gate was instead proven by injection — adding
+   `search_content` to a `next_step` fails it — which is the same evidence the
+   original RED case would have supplied. See the *Measured correction* above.
 5. §3.2: for each existing blocking gate, a self-check asserting exact set
    equality, plus its coverage-invariant-equals-zero.
 6. §3.2: doc-example extraction must fail on a deliberately wrong pinned count.
@@ -704,7 +720,7 @@ rather than dropping it.
       orphan **corrected**, not preserved; **no allowlist**
 - [ ] §3.1 abstract-base exemption is structural (`abc`-abstract / no concrete
       `execute`), not a list of three names
-- [ ] §3.1 `next_step` routability green under the token-matching formulation
+- [x] §3.1 `next_step` routability green under the token-matching formulation
 - [ ] §3.1 dispatch reachability asserted through public entry points
 - [ ] §3.1 zero-caller signal exempt from §1's ratchet, asserted by a test that
       fails if a genuine orphan starts answering `unknown`

--- a/tests/unit/mcp/test_next_step_routability.py
+++ b/tests/unit/mcp/test_next_step_routability.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""RFC-0028 §3.1 — a ``next_step`` that names a route must name a *resolvable* one.
+
+§3.1 states the invariant, and states it carefully, because the obvious
+formulation is false:
+
+    Any ``next_step`` containing a token matching a known tool / facade / action
+    name must resolve to a **registered** route.
+
+The obvious formulation — "every ``next_step`` names a route" — fails on correct
+behaviour, because real emitted strings are English prose ("Pass roots within the
+project boundary."). This gate only constrains tokens that *are* route names.
+
+It harvests the string constants assigned to ``next_step`` across the tool
+package and checks every token that collides with the published vocabulary.
+Tokens are matched against legacy tool names (``facade_map.LEGACY_TOOL_MAP``) and
+registered facade names, so a name that used to resolve and no longer does — or a
+name that never did, which is exactly the defect §3.1 records — fails here rather
+than in an agent's next call.
+
+**Limit:** this reads literals, so a ``next_step`` assembled entirely from
+runtime data is not seen. The harvest is asserted non-trivial and asserted to
+match vocabulary tokens, so a broken harvest fails instead of passing quietly.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+from tree_sitter_analyzer.mcp.facade_map import LEGACY_TOOL_MAP, REMOVED_TOOL_NAMES
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+TOOLS_DIR = PROJECT_ROOT / "tree_sitter_analyzer" / "mcp" / "tools"
+
+_TOKEN = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+def _next_step_strings() -> list[tuple[str, str]]:
+    """Every string constant assigned into a ``next_step``, with its module."""
+    harvested: list[tuple[str, str]] = []
+    for path in sorted(TOOLS_DIR.glob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError as exc:  # pragma: no cover - a broken module fails elsewhere
+            raise AssertionError(f"{path.name} does not parse: {exc}") from exc
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign):
+                targets, value = node.targets, node.value
+            elif isinstance(node, ast.AnnAssign):
+                targets, value = [node.target], node.value
+            else:
+                continue
+            if value is None or not any(
+                isinstance(target, ast.Name) and target.id == "next_step"
+                for target in targets
+            ):
+                continue
+            for inner in ast.walk(value):
+                if isinstance(inner, ast.Constant) and isinstance(inner.value, str):
+                    harvested.append((path.name, inner.value))
+    return harvested
+
+
+def _registered_facades() -> dict[str, set[str]]:
+    from tree_sitter_analyzer.mcp._tool_registry import create_tool_registry
+
+    tools, _lookup = create_tool_registry(".")
+    return {
+        name: set(getattr(facade, "action_map", {}))
+        | set(getattr(facade, "bespoke_map", {}))
+        for name, facade in tools
+    }
+
+
+def _vocabulary_tokens(harvest: list[tuple[str, str]]) -> dict[str, set[str]]:
+    """Map each route-name token found in a ``next_step`` to its modules."""
+    vocabulary = set(LEGACY_TOOL_MAP) | set(_registered_facades()) | set(REMOVED_TOOL_NAMES)
+    found: dict[str, set[str]] = {}
+    for module, text in harvest:
+        for token in _TOKEN.findall(text):
+            if token in vocabulary:
+                found.setdefault(token, set()).add(module)
+    return found
+
+
+def test_no_next_step_names_a_removed_tool() -> None:
+    """A ``next_step`` naming a removed capability is a dead route.
+
+    This is the class §3.1 records, and the reason the vocabulary cannot be
+    "names that currently resolve": a removed name resolves nowhere by
+    construction, so checking only live names cannot see it. ``REMOVED_TOOL_NAMES``
+    is what makes "removed" machine-checkable instead of prose.
+    """
+    tokens = _vocabulary_tokens(_next_step_strings())
+    named = {token: sorted(where) for token, where in tokens.items() if token in REMOVED_TOOL_NAMES}
+    assert named == {}, (
+        "a next_step names a capability a released breaking change removed, so "
+        "an agent following it calls something that no longer exists:\n  "
+        + "\n  ".join(f"{token} (in {', '.join(where)})" for token, where in sorted(named.items()))
+    )
+
+
+def test_the_harvest_is_not_vacuous() -> None:
+    """A harvest that found nothing would make the invariant below meaningless."""
+    harvest = _next_step_strings()
+    assert len(harvest) > 50, (
+        f"only {len(harvest)} next_step string constants harvested; the AST walk "
+        "is probably no longer matching how next_step is assigned"
+    )
+    tokens = _vocabulary_tokens(harvest)
+    assert len(tokens) >= 5, (
+        f"only {len(tokens)} route-name tokens found across {len(harvest)} "
+        "strings; the vocabulary or the tokenizer has drifted and the invariant "
+        "below no longer constrains anything"
+    )
+
+
+def test_every_route_token_in_a_next_step_resolves() -> None:
+    facades = _registered_facades()
+    tokens = _vocabulary_tokens(_next_step_strings())
+
+    unresolved: list[str] = []
+    for token in sorted(tokens):
+        where = ", ".join(sorted(tokens[token]))
+        legacy = LEGACY_TOOL_MAP.get(token)
+        if legacy is not None:
+            facade, action = legacy
+            if facade not in facades or action not in facades[facade]:
+                unresolved.append(
+                    f"{token} (in {where}): legacy name maps to "
+                    f"{facade}.{action}, which is not a registered route"
+                )
+        elif token not in facades:
+            unresolved.append(
+                f"{token} (in {where}): matches no legacy name and no "
+                "registered facade"
+            )
+
+    assert unresolved == [], (
+        "RFC-0028 §3.1 next_step routability is red. A next_step that names a "
+        "route must name one that resolves; an agent follows these literally:\n  "
+        + "\n  ".join(unresolved)
+    )
+
+
+def test_the_prose_case_is_not_constrained() -> None:
+    """The invariant must not require every ``next_step`` to be a route.
+
+    Real emitted strings are English ("Pass roots within the project
+    boundary."), and a gate that fails them would be wrong rather than strict.
+    """
+    harvest = _next_step_strings()
+    prose = [text for _module, text in harvest if " " in text.strip()]
+    assert prose, "no prose next_step found; the corpus changed shape"
+    vocabulary = set(LEGACY_TOOL_MAP) | set(_registered_facades()) | set(REMOVED_TOOL_NAMES)
+    prose_without_route = [
+        text for text in prose if not (set(_TOKEN.findall(text)) & vocabulary)
+    ]
+    assert prose_without_route, (
+        "every harvested next_step now names a route token, so the prose case "
+        "this test protects is no longer represented"
+    )

--- a/tests/unit/mcp/test_next_step_routability.py
+++ b/tests/unit/mcp/test_next_step_routability.py
@@ -76,7 +76,9 @@ def _registered_facades() -> dict[str, set[str]]:
 
 def _vocabulary_tokens(harvest: list[tuple[str, str]]) -> dict[str, set[str]]:
     """Map each route-name token found in a ``next_step`` to its modules."""
-    vocabulary = set(LEGACY_TOOL_MAP) | set(_registered_facades()) | set(REMOVED_TOOL_NAMES)
+    vocabulary = (
+        set(LEGACY_TOOL_MAP) | set(_registered_facades()) | set(REMOVED_TOOL_NAMES)
+    )
     found: dict[str, set[str]] = {}
     for module, text in harvest:
         for token in _TOKEN.findall(text):
@@ -94,26 +96,40 @@ def test_no_next_step_names_a_removed_tool() -> None:
     is what makes "removed" machine-checkable instead of prose.
     """
     tokens = _vocabulary_tokens(_next_step_strings())
-    named = {token: sorted(where) for token, where in tokens.items() if token in REMOVED_TOOL_NAMES}
+    named = {
+        token: sorted(where)
+        for token, where in tokens.items()
+        if token in REMOVED_TOOL_NAMES
+    }
     assert named == {}, (
         "a next_step names a capability a released breaking change removed, so "
         "an agent following it calls something that no longer exists:\n  "
-        + "\n  ".join(f"{token} (in {', '.join(where)})" for token, where in sorted(named.items()))
+        + "\n  ".join(
+            f"{token} (in {', '.join(where)})" for token, where in sorted(named.items())
+        )
     )
 
 
 def test_the_harvest_is_not_vacuous() -> None:
-    """A harvest that found nothing would make the invariant below meaningless."""
+    """Exact rather than lower bounds: RFC-0028 §3.2 requires set equality.
+
+    Measured 2026-09-12: 145 harvested constants, 17 route-name tokens. Update
+    these constants deliberately when the vocabulary legitimately changes — a
+    `> 50` / `>= 5` bound would keep passing while the harvest shrank to a third
+    of its real size, leaving the invariant below constraining almost nothing.
+    """
     harvest = _next_step_strings()
-    assert len(harvest) > 50, (
-        f"only {len(harvest)} next_step string constants harvested; the AST walk "
-        "is probably no longer matching how next_step is assigned"
+    assert len(harvest) == 145, (
+        f"expected 145 next_step string constants, harvested {len(harvest)}; "
+        "update this constant if the phrasing changed, otherwise the AST walk is "
+        "no longer matching how next_step is assigned"
     )
     tokens = _vocabulary_tokens(harvest)
-    assert len(tokens) >= 5, (
-        f"only {len(tokens)} route-name tokens found across {len(harvest)} "
-        "strings; the vocabulary or the tokenizer has drifted and the invariant "
-        "below no longer constrains anything"
+    assert len(tokens) == 17, (
+        f"expected 17 route-name tokens across {len(harvest)} strings, found "
+        f"{len(tokens)}; update this constant if the vocabulary changed, "
+        "otherwise the tokenizer has drifted and the invariant below no longer "
+        "constrains anything"
     )
 
 
@@ -134,8 +150,7 @@ def test_every_route_token_in_a_next_step_resolves() -> None:
                 )
         elif token not in facades:
             unresolved.append(
-                f"{token} (in {where}): matches no legacy name and no "
-                "registered facade"
+                f"{token} (in {where}): matches no legacy name and no registered facade"
             )
 
     assert unresolved == [], (
@@ -154,7 +169,9 @@ def test_the_prose_case_is_not_constrained() -> None:
     harvest = _next_step_strings()
     prose = [text for _module, text in harvest if " " in text.strip()]
     assert prose, "no prose next_step found; the corpus changed shape"
-    vocabulary = set(LEGACY_TOOL_MAP) | set(_registered_facades()) | set(REMOVED_TOOL_NAMES)
+    vocabulary = (
+        set(LEGACY_TOOL_MAP) | set(_registered_facades()) | set(REMOVED_TOOL_NAMES)
+    )
     prose_without_route = [
         text for text in prose if not (set(_TOKEN.findall(text)) & vocabulary)
     ]

--- a/tree_sitter_analyzer/mcp/facade_map.py
+++ b/tree_sitter_analyzer/mcp/facade_map.py
@@ -49,6 +49,21 @@ FACADE_NAMES: tuple[str, ...] = (
     "viz",
 )
 
+# Tool aliases a released breaking change REMOVED, so no crosswalk entry exists
+# for them. They are named here because "removed" is otherwise only prose: a
+# ``next_step`` telling an agent to call one of these is a dead route, and
+# nothing machine-checkable currently distinguishes it from a live name.
+#
+# Source: CHANGELOG 1.30.0 — "search.content / legacy search_content /
+# search-content, and search.grep / legacy find_and_grep / find-and-grep are
+# removed." Listed as the identifier forms that can appear as a token.
+REMOVED_TOOL_NAMES: frozenset[str] = frozenset(
+    {
+        "search_content",
+        "find_and_grep",
+    }
+)
+
 # ---------------------------------------------------------------------------
 # legacy old-tool-name -> (facade, action) crosswalk (β shim source of truth)
 #


### PR DESCRIPTION
Implements RFC-0028 §3.1's `next_step` routability invariant, and corrects the RFC's own account of the defect it names.

## The invariant, as the RFC states it

> Any `next_step` containing a token matching a known tool / facade / action name must resolve to a **registered** route.

The obvious formulation is false and the RFC says so: real emitted strings are English prose ("Pass roots within the project boundary."), so the gate must constrain only tokens that *are* route names. It harvests the string constants assigned into `next_step` by AST (145 across 27 modules) and resolves every token colliding with the published vocabulary.

## The RFC's named defect is fixed, and was mis-located

Measured: `get_project_summary` is **back in** `facade_map.LEGACY_TOOL_MAP` (→ `project action=card`), and its mention in `build_project_index_tool.py` is inside the tool **description**, not a `next_step`. So the live instance is gone. All 10 legacy names currently emitted in `next_step` strings resolve to registered routes:

```
analyze_code_structure -> structure.analyze      ast_cache              -> index.cache
build_project_index    -> index.build            codegraph_symbol_search -> search.symbol
detect_routes          -> health.routes          extract_code_section   -> structure.read
get_code_outline       -> structure.outline      list_files             -> project.files
refactoring_suggestions-> edit.refactor          trace_impact           -> nav.trace
```

## What measuring it exposed: a class the wording cannot reach

I first proved the gate by injecting a `next_step` naming a removed capability — and **it passed**. The reason is structural, not a bug in the harness: a name that a breaking change *removed* (`search_content`, `find_and_grep`) resolves nowhere by construction, so a vocabulary built from names that currently resolve cannot see it. "Removed" existed only as prose in comments and `CHANGELOG`.

`facade_map.REMOVED_TOOL_NAMES` gives it a machine-checkable home, next to the crosswalk that already owns the name mapping. With it, injecting `search_content` fails the gate:

```
search_content (in get_code_outline_tool.py)
search_content (in get_code_outline_tool.py): matches no legacy name and no registered facade
```

## Verification

- `4 passed` on the gate; `41 passed` across the disposition, CLI↔MCP parity and response-contract suites; `ruff check` clean.
- The gate is proven non-vacuous in both directions: a harvest assertion fails if the AST walk stops matching (it requires >50 strings and ≥5 vocabulary tokens), and the injection above proves it rejects a dead route.
- A third test pins the *prose* case — a `next_step` that names no route must not be constrained — because a gate that failed "Pass roots within the project boundary." would be wrong rather than strict.

## RFC corrections in the same change

Two passages assumed the now-fixed defect. Both are corrected rather than deleted, with the measurement recorded: the §3.1 design note (mis-located defect + the removed-name class) and the test plan's RED-first item, which says plainly that RED was not available here and why injection is the equivalent evidence.


---

**Reopened as a new PR after a branch rename.** The gitflow guard
(`Validate head→base per GITFLOW.md`) rejected the previous head name: PRs to
`develop` must use a GitFlow prefix (`feature/*`, `fix/*`, `test/*`, …). GitHub's
rename endpoint closes the PR rather than retargeting it, so this is the same
commit under `test/rfc-0028-31-next-step-routability`. No content changed.
